### PR TITLE
Standardize build metadata and code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,5 @@
-; EditorConfig to support per-solution formatting.
-; Use the EditorConfig VS add-in to make this work.
-; http://editorconfig.org/
-
-; This is the default for the codeline.
+# EditorConfig to support per-solution formatting.
+# http://editorconfig.org/
 root = true
 
 [*]
@@ -10,13 +7,187 @@ indent_style = space
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-; .NET Code - almost, but not exactly, the same suggestions as corefx
-; https://github.com/dotnet/corefx/blob/master/.editorconfig
+# .NET Code
 [*.cs]
 indent_size = 4
 charset = utf-8-bom
 
-; New line preferences
+# .NET project files and MSBuild - match defaults for VS
+[*.{csproj,nuspec,proj,projitems,props,shproj,targets,vbproj,vcxproj,vcxproj.filters,vsixmanifest,vsct}]
+indent_size = 2
+
+# .NET solution files - match defaults for VS
+[*.sln]
+end_of_line = crlf
+indent_style = tab
+
+# .NET XML solution files - match dotnet new sln defaults
+[*.slnx]
+indent_size = 2
+
+
+# Config - match XML and default nuget.config template
+[*.config]
+indent_size = 2
+
+# Resources - match defaults for VS
+[*.resx]
+indent_size = 2
+
+# Static analysis rulesets - match defaults for VS
+[*.ruleset]
+indent_size = 2
+
+# HTML, XML - match defaults for VS
+[*.{cshtml,html,xml}]
+indent_size = 4
+
+# JavaScript and JS mixes - match eslint settings; JSON also matches .NET Core templates
+[*.{js,json,mjs,ts,vue}]
+indent_size = 2
+
+# Markdown - match markdownlint settings
+[*.{md,markdown}]
+indent_size = 2
+
+# PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
+[*.{ps1,psd1,psm1}]
+indent_size = 4
+charset = utf-8-bom
+
+# YAML - match standard YAML like Kubernetes and GitHub Actions
+[*.{yaml,yml}]
+indent_size = 2
+
+# ReStructuredText - standard indentation format from examples
+[*.rst]
+indent_size = 2
+
+#
+# dotnet code style
+#
+[*.cs]
+
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# Avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+dotnet_style_explicit_tuple_names = true:warning
+
+# Whitespace options
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# Non-private static fields are PascalCase
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols = non_private_static_fields
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style = non_private_static_field_style
+
+dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
+
+dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
+
+# Non-private readonly fields are PascalCase
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.symbols = non_private_readonly_fields
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = non_private_readonly_field_style
+
+dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
+
+dotnet_naming_style.non_private_readonly_field_style.capitalization = pascal_case
+
+# Constants are PascalCase
+dotnet_naming_rule.constants_should_be_pascal_case.severity = warning
+dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
+dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
+
+dotnet_naming_symbols.constants.applicable_kinds = field, local
+dotnet_naming_symbols.constants.required_modifiers = const
+
+dotnet_naming_style.constant_style.capitalization = pascal_case
+
+# Static fields should be _camelCase
+dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+
+dotnet_naming_style.static_field_style.capitalization = camel_case
+
+# Instance fields are camelCase and start with _
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
+dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
+
+dotnet_naming_symbols.instance_fields.applicable_kinds = field
+
+dotnet_naming_style.instance_field_style.capitalization = camel_case
+dotnet_naming_style.instance_field_style.required_prefix = _
+
+# Locals and parameters are camelCase
+dotnet_naming_rule.locals_should_be_camel_case.severity = warning
+dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
+dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
+
+dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
+
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# Local functions are PascalCase
+dotnet_naming_rule.local_functions_should_be_pascal_case.severity = warning
+dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
+dotnet_naming_rule.local_functions_should_be_pascal_case.style = local_function_style
+
+dotnet_naming_symbols.local_functions.applicable_kinds = local_function
+
+dotnet_naming_style.local_function_style.capitalization = pascal_case
+
+# By default, name items with PascalCase
+dotnet_naming_rule.members_should_be_pascal_case.severity = warning
+dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
+dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
+
+dotnet_naming_symbols.all_members.applicable_kinds = *
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# IDE0035: Remove unreachable code
+dotnet_diagnostic.IDE0035.severity = warning
+
+# IDE0036: Order modifiers
+dotnet_diagnostic.IDE0036.severity = warning
+
+# IDE0043: Format string contains invalid placeholder
+dotnet_diagnostic.IDE0043.severity = warning
+
+# IDE0044: Make field readonly
+dotnet_diagnostic.IDE0044.severity = warning
+
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = warning
+
+# C# code style
+#
+# Newline settings
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
@@ -25,90 +196,34 @@ csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
-; Indentation preferences
+# Indentation preferences
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
 csharp_indent_case_contents_when_block = true
 csharp_indent_switch_labels = true
-csharp_indent_labels = one_less_than_current
+csharp_indent_labels = flush_left
 
-; Modifier preferences
-csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:warning
+# Whitespace options
+# Each of the *_experimental rules has a corresponding IDE* setting.
+csharp_style_allow_embedded_statements_on_same_line_experimental = false
+dotnet_diagnostic.IDE2001.severity = warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
+dotnet_diagnostic.IDE2002.severity = warning
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
+dotnet_diagnostic.IDE2004.severity = warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = false
+dotnet_diagnostic.IDE2005.severity = warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false
+dotnet_diagnostic.IDE2006.severity = warning
 
-; Avoid this. unless absolutely necessary
-dotnet_style_qualification_for_field = false:suggestion
-dotnet_style_qualification_for_property = false:suggestion
-dotnet_style_qualification_for_method = false:suggestion
-dotnet_style_qualification_for_event = false:suggestion
+# Prefer "var" everywhere
+dotnet_diagnostic.IDE0007.severity = warning
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
 
-; Types: use keywords instead of BCL types, using var is fine.
-csharp_style_var_when_type_is_apparent = false:none
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = true:suggestion
-
-; Name all constant fields using PascalCase
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = warning
-dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.constant_fields.applicable_kinds   = field
-dotnet_naming_symbols.constant_fields.required_modifiers = const
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
-
-; Static fields should be _camelCase
-dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
-dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
-dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
-dotnet_naming_symbols.static_fields.applicable_kinds   = field
-dotnet_naming_symbols.static_fields.required_modifiers = static
-dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
-
-; Static readonly fields should be PascalCase
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.severity = warning
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.symbols  = static_readonly_fields
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.static_readonly_fields.applicable_kinds   = field
-dotnet_naming_symbols.static_readonly_fields.required_modifiers = static, readonly
-dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = private, internal, private_protected
-
-; Internal and private fields should be _camelCase
-dotnet_naming_rule.camel_case_for_private_internal_fields.severity = warning
-dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
-dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
-dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
-dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
-dotnet_naming_style.camel_case_underscore_style.required_prefix = _
-dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
-
-; Code style defaults
-csharp_using_directive_placement = outside_namespace:suggestion
-dotnet_sort_system_directives_first = true
-csharp_prefer_braces = true:refactoring
-csharp_preserve_single_line_blocks = true:none
-csharp_preserve_single_line_statements = false:none
-csharp_prefer_static_local_function = true:suggestion
-csharp_prefer_simple_using_statement = false:none
-csharp_style_prefer_switch_expression = true:suggestion
-
-; Code quality
-dotnet_style_readonly_field = true:suggestion
-dotnet_code_quality_unused_parameters = non_public:suggestion
-
-; Expression-level preferences
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_auto_properties = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring
-dotnet_style_prefer_conditional_expression_over_return = true:refactoring
-csharp_prefer_simple_default_expression = true:suggestion
-
-# Expression-bodied members
+# Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = true:refactoring
 csharp_style_expression_bodied_constructors = true:refactoring
 csharp_style_expression_bodied_operators = true:refactoring
@@ -118,20 +233,15 @@ csharp_style_expression_bodied_accessors = true:refactoring
 csharp_style_expression_bodied_lambdas = true:refactoring
 csharp_style_expression_bodied_local_functions = true:refactoring
 
-# Pattern matching
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-
-# Null checking preferences
-csharp_style_throw_expression = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
-
-# Other features
-csharp_style_namespace_declarations = file_scoped:suggestion
-csharp_style_prefer_index_operator = false:none
-csharp_style_prefer_range_operator = false:none
-csharp_style_pattern_local_over_anonymous_function = false:none
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_inlined_variable_declaration = true:warning
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+csharp_style_prefer_extended_property_pattern = true:warning
+csharp_style_namespace_declarations = file_scoped:warning
+csharp_style_prefer_parameter_null_checking = false
 
 # Space preferences
 csharp_space_after_cast = false
@@ -157,48 +267,30 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
-; .NET project files and MSBuild - match defaults for VS
-[*.{csproj,nuspec,proj,projitems,props,shproj,targets,vbproj,vcxproj,vcxproj.filters,vsixmanifest,vsct}]
-indent_size = 2
+# Blocks required
+csharp_prefer_braces = true:warning
+csharp_preserve_single_line_blocks = false
+csharp_preserve_single_line_statements = false
 
-; .NET solution files - match defaults for VS
-[*.sln]
-end_of_line = crlf
-indent_style = tab
+# IDE0011: Add braces
+csharp_prefer_braces = when_multiline:warning
+# NOTE: We need the below severity entry for Add Braces due to https://github.com/dotnet/roslyn/issues/44201
+dotnet_diagnostic.IDE0011.severity = warning
 
-; Config - match XML and default nuget.config template
-[*.config]
-indent_size = 2
+# IDE0040: Add accessibility modifiers
+dotnet_diagnostic.IDE0040.severity = warning
 
-; Resources - match defaults for VS
-[*.resx]
-indent_size = 2
+# IDE0052: Remove unread private member
+dotnet_diagnostic.IDE0052.severity = warning
 
-; Static analysis rulesets - match defaults for VS
-[*.ruleset]
-indent_size = 2
+# IDE0059: Unnecessary assignment to a value
+dotnet_diagnostic.IDE0059.severity = warning
 
-; HTML, XML - match defaults for VS
-[*.{cshtml,html,xml}]
-indent_size = 4
+# IDE0060: Remove unused parameter
+dotnet_diagnostic.IDE0060.severity = warning
 
-; JavaScript and JS mixes - match eslint settings; JSON also matches .NET Core templates
-[*.{js,json,ts,vue}]
-indent_size = 2
+# CA1012: Abstract types should not have public constructors
+dotnet_diagnostic.CA1012.severity = warning
 
-; Markdown - match markdownlint settings
-[*.{md,markdown}]
-indent_size = 2
-
-; PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
-[*.{ps1,psd1,psm1}]
-indent_size = 4
-charset = utf-8-bom
-
-; ReStructuredText - standard indentation format from examples
-[*.rst]
-indent_size = 2
-
-# YAML - match standard YAML like Kubernetes and GitHub Actions
-[*.{yaml,yml}]
-indent_size = 2
+# CA1822: Make member static
+dotnet_diagnostic.CA1822.severity = warning

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
+    rev: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c"  # frozen: v6.0.0
     hooks:
       - id: check-json
       - id: check-yaml
@@ -8,13 +8,13 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: e72a3ca1632f0b11a07d171449fe447a7ff6795e  # frozen: v0.48.0
+    rev: "e72a3ca1632f0b11a07d171449fe447a7ff6795e"  # frozen: v0.48.0
     hooks:
       - id: markdownlint
         args:
           - --fix
   - repo: https://github.com/tillig/json-sort-cli
-    rev: 2b7e147e0933bd30b58133b6f287e5c695ff4f0e  # frozen: v3.0.1
+    rev: "2b7e147e0933bd30b58133b6f287e5c695ff4f0e"  # frozen: v3.0.1
     hooks:
       - id: json-sort
         args:

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -1,49 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="14.0">
-  <!-- https://github.com/dotnet/roslyn/blob/master/docs/compilers/Rule%20Set%20Format.md -->
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
+  <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
+    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
+    <Rule Id="CA1032" Action="None" />
+    <!-- Avoid excessive inheritance (must be explicitly enabled). -->
+    <Rule Id="CA1501" Action="Warning" />
+    <!-- Avoid excessive complexity (must be explicitly enabled). -->
+    <Rule Id="CA1502" Action="Warning" />
+    <!-- Avoid unmaintainable code (must be explicitly enabled). -->
+    <Rule Id="CA1505" Action="Warning" />
+    <!-- Avoid excessive class coupling (must be explicitly enabled). -->
+    <Rule Id="CA1506" Action="Warning" />
+    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <Rule Id="CA1510" Action="None" />
+    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - this isn't available until we stop targeting anything below net8.0. -->
+    <Rule Id="CA1512" Action="None" />
+    <!-- Use ObjectDisposedException.ThrowIf - this isn't available until we stop targeting anything below net8.0. -->
+    <Rule Id="CA1513" Action="None" />
+    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
+    <Rule Id="CA1716" Action="None" />
+    <!-- Cache a CompositeFormat object for use in String.Format - this isn't available until we stop targeting netstandard, and we only String.Format when throwing exceptions so the work/complexity isn't justified to increase perf just for those situations. -->
+    <Rule Id="CA1863" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core. -->
+    <Rule Id="CA2229" Action="None" />
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
+    <Rule Id="CA2237" Action="None" />
+    <!-- Prefer generic overloads to using Type parameters - many aren't available in earlier frameworks; and we do a lot of reflection work in Autofac. -->
+    <Rule Id="CA2263" Action="None" />
+  </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <!-- Prefix local calls with this -->
+    <!-- Prefix local calls with this. -->
     <Rule Id="SA1101" Action="None" />
-    <!-- Use built-in type alias -->
+    <!-- Use built-in type alias. -->
     <Rule Id="SA1121" Action="None" />
-    <!-- Use String.Empty instead of "" -->
+    <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
-    <!-- Using statements must be inside a namespace -->
-    <Rule Id="SA1200" Action="None" />
-    <!-- Enforce order of class members by member type -->
-    <Rule Id="SA1201" Action="None" />
-    <!-- Enforce order of class members by member visibility -->
-    <Rule Id="SA1202" Action="None" />
-    <!-- Enforce order of constantand static members -->
-    <Rule Id="SA1203" Action="None" />
-    <!-- Enforce order of static vs. non-static members -->
-    <Rule Id="SA1204" Action="None" />
-    <!-- Enforce order of readonly vs. non-readonly members -->
-    <Rule Id="SA1214" Action="None" />
-    <!-- Fields can't start with underscore -->
+    <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
-    <!-- Suppressions must have a justification -->
-    <Rule Id="SA1404" Action="None" />
-    <!-- No single-line statements involving braces -->
-    <Rule Id="SA1501" Action="None" />
-    <!-- Braces must not be omitted -->
-    <Rule Id="SA1503" Action="None" />
-    <!-- Element must be documented -->
-    <Rule Id="SA1600" Action="None" />
-    <!-- Parameter documentation mus be in the right order -->
-    <Rule Id="SA1612" Action="None" />
-    <!-- Return value must be documented -->
-    <Rule Id="SA1615" Action="None" />
-    <!-- Generic type parameters must be documented -->
-    <Rule Id="SA1618" Action="None" />
-    <!-- Don't copy/paste documentation -->
-    <Rule Id="SA1625" Action="None" />
-    <!-- Exception documentation must not be empty -->
-    <Rule Id="SA1627" Action="None" />
-    <!-- File must have header -->
-    <Rule Id="SA1633" Action="None" />
-    <!-- Enable XML documentation output-->
-    <Rule Id="SA1652" Action="None" />
   </Rules>
 </RuleSet>

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -1,0 +1,92 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
+  <IncludeAll Action="Warning" />
+  <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
+    <!-- Avoid excessive parameters on generic types (must be explicitly enabled). -->
+    <Rule Id="CA1005" Action="Warning" />
+    <!-- Don't catch general exceptions - test scenarios sometimes require general exception handling. -->
+    <Rule Id="CA1031" Action="None" />
+    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
+    <Rule Id="CA1032" Action="None" />
+    <!-- Avoid empty interfaces - in unit tests for service resolution, this happens a lot. -->
+    <Rule Id="CA1040" Action="None" />
+    <!-- Do not pass literals as localized parameters  - tests don't need to localize. -->
+    <Rule Id="CA1303" Action="None" />
+    <!-- Avoid excessive inheritance (must be explicitly enabled). -->
+    <Rule Id="CA1501" Action="Warning" />
+    <!-- Avoid excessive complexity (must be explicitly enabled). -->
+    <Rule Id="CA1502" Action="Warning" />
+    <!-- Avoid unmaintainable code (must be explicitly enabled). -->
+    <Rule Id="CA1505" Action="Warning" />
+    <!-- Avoid excessive class coupling (must be explicitly enabled). -->
+    <Rule Id="CA1506" Action="Warning" />
+    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <Rule Id="CA1510" Action="None" />
+    <!-- Make API types internal - causes problems with tests and test assemblies. -->
+    <Rule Id="CA1515" Action="None" />
+    <!-- Remove the underscores from member name - unit test scenarios may use underscores. -->
+    <Rule Id="CA1707" Action="None" />
+    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
+    <Rule Id="CA1716" Action="None" />
+    <!-- Internal class that appears to never be instantiated - lots of false positives here because they're test stubs created by Autofac registrations. -->
+    <Rule Id="CA1812" Action="None" />
+    <!-- Change Dispose() to call GC.SuppressFinalize - in tests we don't really care and it can impact readability. -->
+    <Rule Id="CA1816" Action="None" />
+    <!-- Mark members static - test methods may not access member data but also can't be static. -->
+    <Rule Id="CA1822" Action="None" />
+    <!-- Seal internal types for performance - in tests we don't really care and it gets painful to enforce. -->
+    <Rule Id="CA1852" Action="None" />
+    <!-- Prefer static readonly fields over constant array arguments - constant array arguments happen a lot in unit tests for assertions and test setup. -->
+    <Rule Id="CA1861" Action="None" />
+    <!-- Cache a CompositeFormat object for use in String.Format - this makes unit tests harder to read, and performance isn't an issue. -->
+    <Rule Id="CA1863" Action="None" />
+    <!-- Call ConfigureAwait on tasks - you shouldn't do this in unit test libraries; XUnit has an opposite analyzer. -->
+    <Rule Id="CA2007" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core. -->
+    <Rule Id="CA2229" Action="None" />
+    <!-- Use Uri instead of string parameters - strings are easier for testing. -->
+    <Rule Id="CA2234" Action="None" />
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
+    <Rule Id="CA2237" Action="None" />
+    <!-- Prefer generic overloads to using Type parameters - we do a lot of reflection work in Autofac that needs to be tested. -->
+    <Rule Id="CA2263" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <!-- Prefix local calls with this. -->
+    <Rule Id="SA1101" Action="None" />
+    <!-- Use built-in type alias. -->
+    <Rule Id="SA1121" Action="None" />
+    <!-- Use String.Empty instead of "". -->
+    <Rule Id="SA1122" Action="None" />
+    <!-- Enforce order of class members by member type - sometimes putting test classes/data by the test helps. -->
+    <Rule Id="SA1201" Action="None" />
+    <!-- Enforce order of class members by member visibility - sometimes putting test classes/data by the test helps. -->
+    <Rule Id="SA1202" Action="None" />
+    <!-- Enforce order of static vs. non-static members - sometimes putting test classes/data by the test helps. -->
+    <Rule Id="SA1204" Action="None" />
+    <!-- Fields can't start with underscore. -->
+    <Rule Id="SA1309" Action="None" />
+    <!-- Elements should be documented. -->
+    <Rule Id="SA1600" Action="None" />
+    <!-- Partial items should be documented. -->
+    <Rule Id="SA1601" Action="None" />
+    <!-- Enumeration items should be documented. -->
+    <Rule Id="SA1602" Action="None" />
+    <!-- Parameter should be documented. -->
+    <Rule Id="SA1611" Action="None" />
+    <!-- Parameter documentation must be in the right order. -->
+    <Rule Id="SA1612" Action="None" />
+    <!-- Return value must be documented. -->
+    <Rule Id="SA1615" Action="None" />
+    <!-- Generic type parameters must be documented. -->
+    <Rule Id="SA1618" Action="None" />
+    <!-- Don't copy/paste documentation. -->
+    <Rule Id="SA1625" Action="None" />
+    <!-- Private member is unused - tests for reflection require members that may not get used. -->
+    <Rule Id="IDE0051" Action="None" />
+    <!-- Private member assigned value never read - tests for reflection require values that may not get used. -->
+    <Rule Id="IDE0052" Action="None" />
+    <!-- Remove unused parameter - tests for reflection require parameters that may not get used. -->
+    <Rule Id="IDE0060" Action="None" />
+  </Rules>
+</RuleSet>

--- a/build/stylecop.json
+++ b/build/stylecop.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "Autofac Project",
+      "copyrightText": "Copyright (c) {companyName}. All rights reserved.\nLicensed under the {licenseName} License. See {licenseFile} in the project root for license information.",
+      "variables": {
+        "licenseFile": "LICENSE",
+        "licenseName": "MIT"
+      },
+      "xmlHeader": false
+    },
+    "orderingRules": {
+      "usingDirectivesPlacement": "outsideNamespace"
+    }
+  }
+}

--- a/default.proj
+++ b/default.proj
@@ -56,7 +56,8 @@
     <Exec Command="dotnet build &quot;%(SolutionFile.FullPath)&quot; -c $(Configuration) /p:Version=$(Version)" />
   </Target>
   <Target Name="Package">
-    <Exec Command="dotnet pack &quot;%(SolutionFile.FullPath)&quot; -c $(Configuration) --output &quot;$(PackageDirectory)&quot; /p:Version=$(Version)" />
+    <MakeDir Directories="$(PackageDirectory)" />
+    <Exec Command="dotnet pack &quot;%(SourceProject.Identity)&quot; -c $(Configuration) --no-build --output &quot;$(PackageDirectory)&quot; /p:Version=$(Version)" />
   </Target>
   <Target Name="Test">
     <MakeDir Directories="$(LogDirectory)" />

--- a/src/Autofac.Multitenant.Wcf/DynamicProxy/CustomAttributeDataExtensions.cs
+++ b/src/Autofac.Multitenant.Wcf/DynamicProxy/CustomAttributeDataExtensions.cs
@@ -1,65 +1,65 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// <copyright file="CustomAttributeDataExtensions.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Autofac.Multitenant.Wcf.DynamicProxy;
 
 using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
 
-namespace Autofac.Multitenant.Wcf.DynamicProxy
+/// <summary>
+/// Extension methods for <see cref="CustomAttributeData"/>.
+/// </summary>
+public static class CustomAttributeDataExtensions
 {
     /// <summary>
-    /// Extension methods for <see cref="CustomAttributeData"/>.
+    /// Converts a custom attribute data object to a custom attribute builder for code generation.
     /// </summary>
-    public static class CustomAttributeDataExtensions
+    /// <param name="data">The data about a custom attribute to be converted for code emission.</param>
+    /// <returns>
+    /// A <see cref="CustomAttributeBuilder"/> with
+    /// the same values as <paramref name="data" /> so it can be copied
+    /// to another member in code generation.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="data" /> is <see langword="null" />.
+    /// </exception>
+    public static CustomAttributeBuilder ToAttributeBuilder(this CustomAttributeData data)
     {
-        /// <summary>
-        /// Converts a custom attribute data object to a custom attribute builder for code generation.
-        /// </summary>
-        /// <param name="data">The data about a custom attribute to be converted for code emission.</param>
-        /// <returns>
-        /// A <see cref="CustomAttributeBuilder"/> with
-        /// the same values as <paramref name="data" /> so it can be copied
-        /// to another member in code generation.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="data" /> is <see langword="null" />.
-        /// </exception>
-        public static CustomAttributeBuilder ToAttributeBuilder(this CustomAttributeData data)
+        if (data == null)
         {
-            if (data == null)
-            {
-                throw new ArgumentNullException(nameof(data));
-            }
-
-            var constructorArguments = new List<object>();
-            foreach (var ctorArg in data.ConstructorArguments)
-            {
-                constructorArguments.Add(ctorArg.Value);
-            }
-
-            var propertyArguments = new List<PropertyInfo>();
-            var propertyArgumentValues = new List<object>();
-            var fieldArguments = new List<FieldInfo>();
-            var fieldArgumentValues = new List<object>();
-            foreach (var namedArg in data.NamedArguments)
-            {
-                var fi = namedArg.MemberInfo as FieldInfo;
-                var pi = namedArg.MemberInfo as PropertyInfo;
-
-                if (fi != null)
-                {
-                    fieldArguments.Add(fi);
-                    fieldArgumentValues.Add(namedArg.TypedValue.Value);
-                }
-                else if (pi != null)
-                {
-                    propertyArguments.Add(pi);
-                    propertyArgumentValues.Add(namedArg.TypedValue.Value);
-                }
-            }
-
-            return new CustomAttributeBuilder(data.Constructor, constructorArguments.ToArray(), propertyArguments.ToArray(), propertyArgumentValues.ToArray(), fieldArguments.ToArray(), fieldArgumentValues.ToArray());
+            throw new ArgumentNullException(nameof(data));
         }
+
+        var constructorArguments = new List<object>();
+        foreach (var ctorArg in data.ConstructorArguments)
+        {
+            constructorArguments.Add(ctorArg.Value);
+        }
+
+        var propertyArguments = new List<PropertyInfo>();
+        var propertyArgumentValues = new List<object>();
+        var fieldArguments = new List<FieldInfo>();
+        var fieldArgumentValues = new List<object>();
+        foreach (var namedArg in data.NamedArguments)
+        {
+            var fi = namedArg.MemberInfo as FieldInfo;
+            var pi = namedArg.MemberInfo as PropertyInfo;
+
+            if (fi != null)
+            {
+                fieldArguments.Add(fi);
+                fieldArgumentValues.Add(namedArg.TypedValue.Value);
+            }
+            else if (pi != null)
+            {
+                propertyArguments.Add(pi);
+                propertyArgumentValues.Add(namedArg.TypedValue.Value);
+            }
+        }
+
+        return new CustomAttributeBuilder(data.Constructor, constructorArguments.ToArray(), propertyArguments.ToArray(), propertyArgumentValues.ToArray(), fieldArguments.ToArray(), fieldArgumentValues.ToArray());
     }
 }

--- a/src/Autofac.Multitenant.Wcf/DynamicProxy/IgnoreAttributeInterfaceProxyInstanceContributor.cs
+++ b/src/Autofac.Multitenant.Wcf/DynamicProxy/IgnoreAttributeInterfaceProxyInstanceContributor.cs
@@ -1,5 +1,8 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// <copyright file="IgnoreAttributeInterfaceProxyInstanceContributor.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Autofac.Multitenant.Wcf.DynamicProxy;
 
 using System;
 using System.ServiceModel;
@@ -8,65 +11,62 @@ using Castle.DynamicProxy.Contributors;
 using Castle.DynamicProxy.Generators.Emitters;
 using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 
-namespace Autofac.Multitenant.Wcf.DynamicProxy
+/// <summary>
+/// Code generator that ignores type-level non-inherited attributes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The default behavior of <see cref="InterfaceProxyInstanceContributor"/>
+/// is to generate a type definition that copies over all of the non-inherited
+/// attributes from the target interface. This includes the <see cref="ServiceContractAttribute"/>
+/// that would be copied over from service interfaces. Unfortunately, WCF
+/// doesn't allow a type marked with <see cref="ServiceContractAttribute"/>
+/// to also implement an interface marked with <see cref="ServiceContractAttribute"/>.
+/// This code generator does everything that <see cref="InterfaceProxyInstanceContributor"/>
+/// does except it doesn't copy over type-level non-inherited attributes.
+/// </para>
+/// </remarks>
+public class IgnoreAttributeInterfaceProxyInstanceContributor : InterfaceProxyInstanceContributor
 {
     /// <summary>
-    /// Code generator that ignores type-level non-inherited attributes.
+    /// Initializes a new instance of the <see cref="IgnoreAttributeInterfaceProxyInstanceContributor"/> class.
     /// </summary>
+    /// <param name="targetType">Type of the target to proxy.</param>
+    /// <param name="proxyGeneratorId">The proxy generator ID.</param>
+    /// <param name="interfaces">The additional interfaces to implement.</param>
+    public IgnoreAttributeInterfaceProxyInstanceContributor(Type targetType, string proxyGeneratorId, Type[] interfaces)
+        : base(targetType, proxyGeneratorId, interfaces)
+    {
+    }
+
+    /// <summary>
+    /// Generates the class defined by the provided class emitter.
+    /// </summary>
+    /// <param name="class">
+    /// The <see cref="ClassEmitter"/>
+    /// being used to build the target type.
+    /// </param>
+    /// <param name="options">The options to use during proxy generation.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="class" /> is <see langword="null" />.
+    /// </exception>
     /// <remarks>
     /// <para>
-    /// The default behavior of <see cref="InterfaceProxyInstanceContributor"/>
-    /// is to generate a type definition that copies over all of the non-inherited
-    /// attributes from the target interface. This includes the <see cref="ServiceContractAttribute"/>
-    /// that would be copied over from service interfaces. Unfortunately, WCF
-    /// doesn't allow a type marked with <see cref="ServiceContractAttribute"/>
-    /// to also implement an interface marked with <see cref="ServiceContractAttribute"/>.
-    /// This code generator does everything that <see cref="InterfaceProxyInstanceContributor"/>
-    /// does except it doesn't copy over type-level non-inherited attributes.
+    /// This overridden version of the method does everything that the base
+    /// <see cref="ProxyInstanceContributor.Generate"/>
+    /// method does but it skips the part where it checks for non-inherited
+    /// attributes and copies them over from the proxy target.
     /// </para>
     /// </remarks>
-    public class IgnoreAttributeInterfaceProxyInstanceContributor : InterfaceProxyInstanceContributor
+    public override void Generate(ClassEmitter @class, ProxyGenerationOptions options)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IgnoreAttributeInterfaceProxyInstanceContributor"/> class.
-        /// </summary>
-        /// <param name="targetType">Type of the target to proxy.</param>
-        /// <param name="proxyGeneratorId">The proxy generator ID.</param>
-        /// <param name="interfaces">The additional interfaces to implement.</param>
-        public IgnoreAttributeInterfaceProxyInstanceContributor(Type targetType, string proxyGeneratorId, Type[] interfaces)
-            : base(targetType, proxyGeneratorId, interfaces)
+        if (@class == null)
         {
+            throw new ArgumentNullException(nameof(@class));
         }
 
-        /// <summary>
-        /// Generates the class defined by the provided class emitter.
-        /// </summary>
-        /// <param name="class">
-        /// The <see cref="ClassEmitter"/>
-        /// being used to build the target type.
-        /// </param>
-        /// <param name="options">The options to use during proxy generation.</param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="class" /> is <see langword="null" />.
-        /// </exception>
-        /// <remarks>
-        /// <para>
-        /// This overridden version of the method does everything that the base
-        /// <see cref="ProxyInstanceContributor.Generate"/>
-        /// method does but it skips the part where it checks for non-inherited
-        /// attributes and copies them over from the proxy target.
-        /// </para>
-        /// </remarks>
-        public override void Generate(ClassEmitter @class, ProxyGenerationOptions options)
-        {
-            if (@class == null)
-            {
-                throw new ArgumentNullException(nameof(@class));
-            }
-
-            FieldReference field = @class.GetField("__interceptors");
-            this.ImplementGetObjectData(@class);
-            this.ImplementProxyTargetAccessor(@class, field);
-        }
+        var field = @class.GetField("__interceptors");
+        this.ImplementGetObjectData(@class);
+        this.ImplementProxyTargetAccessor(@class, field);
     }
 }

--- a/src/Autofac.Multitenant.Wcf/DynamicProxy/ServiceHostInterfaceProxyGenerator.cs
+++ b/src/Autofac.Multitenant.Wcf/DynamicProxy/ServiceHostInterfaceProxyGenerator.cs
@@ -1,5 +1,8 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// <copyright file="ServiceHostInterfaceProxyGenerator.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Autofac.Multitenant.Wcf.DynamicProxy;
 
 using System;
 using System.Collections.Generic;
@@ -10,168 +13,165 @@ using Castle.DynamicProxy.Generators;
 using Castle.DynamicProxy.Generators.Emitters;
 using Castle.DynamicProxy.Internal;
 
-namespace Autofac.Multitenant.Wcf.DynamicProxy
+/// <summary>
+/// Interface proxy generator that builds a proxy that has a default constructor
+/// and does not copy over non-inherited type attributes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The standard <see cref="InterfaceProxyWithTargetInterfaceGenerator"/>
+/// builds a proxy object that has no default constructor. While a default
+/// constructor is not useful from an actual proxying standpoint, the WCF
+/// service host will only host object types that have default constructors.
+/// As such, if we want to start the service host with a proxy type, the
+/// proxy type has to have a default constructor.
+/// </para>
+/// <para>
+/// Also, the standard <see cref="InterfaceProxyWithTargetInterfaceGenerator"/>
+/// generates a type that copies all of the non-inherited attributes over
+/// from the target interface, which causes WCF to choke on the
+/// <see cref="ServiceContractAttribute"/>, which is
+/// already on the service contract interface. This generator overrides
+/// <see cref="GetTypeImplementerMapping"/>
+/// to change the set of code generating contributors to make a slimmer
+/// proxy that WCF hosting will accept.
+/// </para>
+/// </remarks>
+/// <seealso cref="IgnoreAttributeInterfaceProxyInstanceContributor"/>
+public class ServiceHostInterfaceProxyGenerator : InterfaceProxyWithTargetInterfaceGenerator
 {
     /// <summary>
-    /// Interface proxy generator that builds a proxy that has a default constructor
-    /// and does not copy over non-inherited type attributes.
+    /// Holds the metadata buddy class type for the service interface.
     /// </summary>
+    private readonly Type _metadataBuddyType;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServiceHostInterfaceProxyGenerator"/> class.
+    /// </summary>
+    /// <param name="scope">The scope of the module being built.</param>
+    /// <param name="interface">The interface that will be proxied.</param>
+    public ServiceHostInterfaceProxyGenerator(ModuleScope scope, Type @interface)
+        : base(scope, @interface)
+    {
+        _metadataBuddyType = @interface.GetMetadataClassType();
+    }
+
+    // If it turns out the proxy type needs a parameterless constructor,
+    // override the BuildClassEmitter method here, call base, and then
+    // add a constructor to the ClassEmitter like this:
+    // emitter.CreateConstructor(new ArgumentReference[0]);
+
+    // If it turns out custom attributes also need to be copied at the
+    // method/property/field level, the appropriate overrides need to happen
+    // just like the CreateTypeAttributes override, below.
+
+    /// <summary>
+    /// Adds custom attributes to the generated type.
+    /// </summary>
+    /// <param name="emitter">The class emitter.</param>
     /// <remarks>
     /// <para>
-    /// The standard <see cref="InterfaceProxyWithTargetInterfaceGenerator"/>
-    /// builds a proxy object that has no default constructor. While a default
-    /// constructor is not useful from an actual proxying standpoint, the WCF
-    /// service host will only host object types that have default constructors.
-    /// As such, if we want to start the service host with a proxy type, the
-    /// proxy type has to have a default constructor.
-    /// </para>
-    /// <para>
-    /// Also, the standard <see cref="InterfaceProxyWithTargetInterfaceGenerator"/>
-    /// generates a type that copies all of the non-inherited attributes over
-    /// from the target interface, which causes WCF to choke on the
-    /// <see cref="ServiceContractAttribute"/>, which is
-    /// already on the service contract interface. This generator overrides
-    /// <see cref="GetTypeImplementerMapping"/>
-    /// to change the set of code generating contributors to make a slimmer
-    /// proxy that WCF hosting will accept.
+    /// This override calls the base functionality and then uses the metadata
+    /// buddy class (as specified by a <see cref="ServiceMetadataTypeAttribute"/>
+    /// on the service interface) to copy over class-level attributes to the
+    /// dynamic hosting proxy.
     /// </para>
     /// </remarks>
-    /// <seealso cref="IgnoreAttributeInterfaceProxyInstanceContributor"/>
-    public class ServiceHostInterfaceProxyGenerator : InterfaceProxyWithTargetInterfaceGenerator
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="emitter" /> is <see langword="null" />.
+    /// </exception>
+    protected override void CreateTypeAttributes(ClassEmitter emitter)
     {
-        /// <summary>
-        /// Holds the metadata buddy class type for the service interface.
-        /// </summary>
-        private readonly Type _metadataBuddyType;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ServiceHostInterfaceProxyGenerator"/> class.
-        /// </summary>
-        /// <param name="scope">The scope of the module being built.</param>
-        /// <param name="interface">The interface that will be proxied.</param>
-        public ServiceHostInterfaceProxyGenerator(ModuleScope scope, Type @interface)
-            : base(scope, @interface)
+        if (emitter == null)
         {
-            _metadataBuddyType = @interface.GetMetadataClassType();
+            throw new ArgumentNullException(nameof(emitter));
         }
 
-        // If it turns out the proxy type needs a parameterless constructor,
-        // override the BuildClassEmitter method here, call base, and then
-        // add a constructor to the ClassEmitter like this:
-        // emitter.CreateConstructor(new ArgumentReference[0]);
-
-        // If it turns out custom attributes also need to be copied at the
-        // method/property/field level, the appropriate overrides need to happen
-        // just like the CreateTypeAttributes override, below.
-
-        /// <summary>
-        /// Adds custom attributes to the generated type.
-        /// </summary>
-        /// <param name="emitter">The class emitter.</param>
-        /// <remarks>
-        /// <para>
-        /// This override calls the base functionality and then uses the metadata
-        /// buddy class (as specified by a <see cref="ServiceMetadataTypeAttribute"/>
-        /// on the service interface) to copy over class-level attributes to the
-        /// dynamic hosting proxy.
-        /// </para>
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="emitter" /> is <see langword="null" />.
-        /// </exception>
-        protected override void CreateTypeAttributes(ClassEmitter emitter)
+        base.CreateTypeAttributes(emitter);
+        if (_metadataBuddyType == null)
         {
-            if (emitter == null)
-            {
-                throw new ArgumentNullException(nameof(emitter));
-            }
-
-            base.CreateTypeAttributes(emitter);
-            if (_metadataBuddyType == null)
-            {
-                return;
-            }
-
-            var attribs = _metadataBuddyType.GetCustomAttributesData();
-            foreach (var attrib in attribs)
-            {
-                var builder = attrib.ToAttributeBuilder();
-                emitter.DefineCustomAttribute(builder);
-            }
+            return;
         }
 
-        /// <summary>
-        /// Gets the contributors for generating the type definition.
-        /// </summary>
-        /// <param name="interfaces">Additional interfaces to implement.</param>
-        /// <param name="proxyTargetType">The target type for the proxy.</param>
-        /// <param name="contributors">The list of contributors that will be used to generate the type.</param>
-        /// <param name="namingScope">The proxy type naming scope.</param>
-        /// <returns>
-        /// The list of types being implemented.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// This version of the method basically does the same thing as the
-        /// original/base implementation but with these key differences:
-        /// </para>
-        /// <list type="bullet">
-        /// <item>
-        /// <term>No mixin support</term>
-        /// <description>
-        /// The original version of the method looks at the <see cref="BaseProxyGenerator.ProxyGenerationOptions"/>
-        /// to see if there are any mixins to be added to the generated proxy.
-        /// There is no need for mixin support in WCF service hosting so mixins
-        /// aren't even checked for and won't be added.
-        /// </description>
-        /// </item>
-        /// <item>
-        /// <term>No additional interfaces</term>
-        /// <description>
-        /// The original version of the method goes through each of the additional
-        /// interfaces that the are to be implemented, checks them against collisions
-        /// with mixin definitions, and adds type mappings for the additional interfaces.
-        /// The only interface that needs to be implemented for the WCF hosting
-        /// proxy is the service interface, so all of that additional interface
-        /// checking is skipped.
-        /// </description>
-        /// </item>
-        /// <item>
-        /// <term>Custom instance contributor used</term>
-        /// <description>
-        /// The original version of the method uses the
-        /// <see cref="InterfaceProxyInstanceContributor"/>
-        /// as the code generator for the proxy type. Unfortunately, that contributor
-        /// copies over all non-inherited attributes on the interface including
-        /// the <see cref="ServiceContractAttribute"/>. The
-        /// concrete proxy type can't have that attribute because the interface
-        /// already has it, so WCF hosting dies. This version of the method uses
-        /// the <see cref="IgnoreAttributeInterfaceProxyInstanceContributor"/>
-        /// which does not copy over non-inherited attributes.
-        /// </description>
-        /// </item>
-        /// </list>
-        /// </remarks>
-        /// <seealso cref="IgnoreAttributeInterfaceProxyInstanceContributor"/>
-        protected override IEnumerable<Type> GetTypeImplementerMapping(Type[] interfaces, Type proxyTargetType, out IEnumerable<ITypeContributor> contributors, INamingScope namingScope)
+        var attribs = _metadataBuddyType.GetCustomAttributesData();
+        foreach (var attrib in attribs)
         {
-            var typeImplementerMapping = new Dictionary<Type, ITypeContributor>();
-            var allInterfaces = TypeUtil.GetAllInterfaces(new[] { proxyTargetType });
-            var additionalInterfaces = TypeUtil.GetAllInterfaces(interfaces);
-            var implementer = AddMappingForTargetType(typeImplementerMapping, proxyTargetType, allInterfaces, additionalInterfaces, namingScope);
-            var instance = new IgnoreAttributeInterfaceProxyInstanceContributor(targetType, GeneratorType, interfaces);
-            AddMappingForISerializable(typeImplementerMapping, instance);
-            try
-            {
-                AddMappingNoCheck(typeof(IProxyTargetAccessor), instance, typeImplementerMapping);
-            }
-            catch (ArgumentException)
-            {
-                HandleExplicitlyPassedProxyTargetAccessor(allInterfaces, additionalInterfaces);
-            }
-
-            contributors = new List<ITypeContributor> { implementer, instance };
-            return typeImplementerMapping.Keys;
+            var builder = attrib.ToAttributeBuilder();
+            emitter.DefineCustomAttribute(builder);
         }
+    }
+
+    /// <summary>
+    /// Gets the contributors for generating the type definition.
+    /// </summary>
+    /// <param name="interfaces">Additional interfaces to implement.</param>
+    /// <param name="proxyTargetType">The target type for the proxy.</param>
+    /// <param name="contributors">The list of contributors that will be used to generate the type.</param>
+    /// <param name="namingScope">The proxy type naming scope.</param>
+    /// <returns>
+    /// The list of types being implemented.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// This version of the method basically does the same thing as the
+    /// original/base implementation but with these key differences:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>
+    /// <term>No mixin support</term>
+    /// <description>
+    /// The original version of the method looks at the <see cref="BaseProxyGenerator.ProxyGenerationOptions"/>
+    /// to see if there are any mixins to be added to the generated proxy.
+    /// There is no need for mixin support in WCF service hosting so mixins
+    /// aren't even checked for and won't be added.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <term>No additional interfaces</term>
+    /// <description>
+    /// The original version of the method goes through each of the additional
+    /// interfaces that the are to be implemented, checks them against collisions
+    /// with mixin definitions, and adds type mappings for the additional interfaces.
+    /// The only interface that needs to be implemented for the WCF hosting
+    /// proxy is the service interface, so all of that additional interface
+    /// checking is skipped.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <term>Custom instance contributor used</term>
+    /// <description>
+    /// The original version of the method uses the
+    /// <see cref="InterfaceProxyInstanceContributor"/>
+    /// as the code generator for the proxy type. Unfortunately, that contributor
+    /// copies over all non-inherited attributes on the interface including
+    /// the <see cref="ServiceContractAttribute"/>. The
+    /// concrete proxy type can't have that attribute because the interface
+    /// already has it, so WCF hosting dies. This version of the method uses
+    /// the <see cref="IgnoreAttributeInterfaceProxyInstanceContributor"/>
+    /// which does not copy over non-inherited attributes.
+    /// </description>
+    /// </item>
+    /// </list>
+    /// </remarks>
+    /// <seealso cref="IgnoreAttributeInterfaceProxyInstanceContributor"/>
+    protected override IEnumerable<Type> GetTypeImplementerMapping(Type[] interfaces, Type proxyTargetType, out IEnumerable<ITypeContributor> contributors, INamingScope namingScope)
+    {
+        var typeImplementerMapping = new Dictionary<Type, ITypeContributor>();
+        var allInterfaces = TypeUtil.GetAllInterfaces(new[] { proxyTargetType });
+        var additionalInterfaces = TypeUtil.GetAllInterfaces(interfaces);
+        var implementer = AddMappingForTargetType(typeImplementerMapping, proxyTargetType, allInterfaces, additionalInterfaces, namingScope);
+        var instance = new IgnoreAttributeInterfaceProxyInstanceContributor(targetType, GeneratorType, interfaces);
+        AddMappingForISerializable(typeImplementerMapping, instance);
+        try
+        {
+            AddMappingNoCheck(typeof(IProxyTargetAccessor), instance, typeImplementerMapping);
+        }
+        catch (ArgumentException)
+        {
+            HandleExplicitlyPassedProxyTargetAccessor(allInterfaces, additionalInterfaces);
+        }
+
+        contributors = new List<ITypeContributor> { implementer, instance };
+        return typeImplementerMapping.Keys;
     }
 }

--- a/src/Autofac.Multitenant.Wcf/DynamicProxy/ServiceHostProxyBuilder.cs
+++ b/src/Autofac.Multitenant.Wcf/DynamicProxy/ServiceHostProxyBuilder.cs
@@ -1,5 +1,8 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// <copyright file="ServiceHostProxyBuilder.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Autofac.Multitenant.Wcf.DynamicProxy;
 
 using System;
 using System.Globalization;
@@ -8,79 +11,76 @@ using Autofac.Multitenant.Wcf.Properties;
 using Castle.DynamicProxy;
 using Castle.DynamicProxy.Generators;
 
-namespace Autofac.Multitenant.Wcf.DynamicProxy
+/// <summary>
+/// Proxy builder that has an additional method to create proxies usable
+/// in WCF multitenant hosting.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The primary point of interest in this builder type is the
+/// <see cref="CreateWcfProxyType"/>
+/// method, which is used to create an interface proxy type that is hostable
+/// by WCF.
+/// </para>
+/// </remarks>
+[SecurityCritical]
+public class ServiceHostProxyBuilder : DefaultProxyBuilder
 {
     /// <summary>
-    /// Proxy builder that has an additional method to create proxies usable
-    /// in WCF multitenant hosting.
+    /// Creates an interface proxy type that can be used by the WCF host.
     /// </summary>
+    /// <param name="interfaceToProxy">The service interface to proxy.</param>
+    /// <returns>
+    /// A <see cref="Type"/> that is a proxy for the interface specified
+    /// by <paramref name="interfaceToProxy" /> that will be able to be
+    /// hosted by WCF.
+    /// </returns>
     /// <remarks>
     /// <para>
-    /// The primary point of interest in this builder type is the
-    /// <see cref="CreateWcfProxyType"/>
-    /// method, which is used to create an interface proxy type that is hostable
-    /// by WCF.
+    /// This proxy type creation method uses the
+    /// <see cref="ServiceHostInterfaceProxyGenerator"/>
+    /// to create the service host proxy type. As this is a very specialized
+    /// proxy type, it does not take options like other proxy types.
     /// </para>
     /// </remarks>
-    [SecurityCritical]
-    public class ServiceHostProxyBuilder : DefaultProxyBuilder
+    /// <seealso cref="ServiceHostInterfaceProxyGenerator" />
+    public virtual Type CreateWcfProxyType(Type interfaceToProxy)
     {
-        /// <summary>
-        /// Validates that the target type to proxy is visible and not generic.
-        /// </summary>
-        /// <param name="target">
-        /// The interface type to proxy.
-        /// </param>
-        private static void AssertValidType(Type target)
+        if (interfaceToProxy == null)
         {
-            // This is copied from the DefaultProxyBuilder because we need to
-            // validate types but the validation logic is not accessible.
-            var isTargetNested = target.IsNested;
-            var isNestedAndInternal = isTargetNested && (target.IsNestedAssembly || target.IsNestedFamORAssem);
-            var isInternalNotNested = target.IsVisible == false && isTargetNested == false;
-
-            var internalAndVisibleToDynProxy = (isInternalNotNested || isNestedAndInternal) && ProxyUtil.IsAccessible(target);
-            var isAccessible = target.IsPublic || target.IsNestedPublic || internalAndVisibleToDynProxy;
-
-            if (!isAccessible)
-            {
-                throw new GeneratorException(string.Format(CultureInfo.CurrentCulture, Resources.DynamicProxy_InterfaceTypeToProxyNotPublic, target.FullName));
-            }
-
-            if (target.IsGenericTypeDefinition)
-            {
-                throw new GeneratorException(string.Format(CultureInfo.CurrentCulture, Resources.DynamicProxy_InterfaceTypeToProxyIsGeneric, target.FullName));
-            }
+            throw new ArgumentNullException(nameof(interfaceToProxy));
         }
 
-        /// <summary>
-        /// Creates an interface proxy type that can be used by the WCF host.
-        /// </summary>
-        /// <param name="interfaceToProxy">The service interface to proxy.</param>
-        /// <returns>
-        /// A <see cref="Type"/> that is a proxy for the interface specified
-        /// by <paramref name="interfaceToProxy" /> that will be able to be
-        /// hosted by WCF.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// This proxy type creation method uses the
-        /// <see cref="ServiceHostInterfaceProxyGenerator"/>
-        /// to create the service host proxy type. As this is a very specialized
-        /// proxy type, it does not take options like other proxy types.
-        /// </para>
-        /// </remarks>
-        /// <seealso cref="ServiceHostInterfaceProxyGenerator" />
-        public virtual Type CreateWcfProxyType(Type interfaceToProxy)
-        {
-            if (interfaceToProxy == null)
-            {
-                throw new ArgumentNullException(nameof(interfaceToProxy));
-            }
+        AssertValidType(interfaceToProxy);
+        var generator = new ServiceHostInterfaceProxyGenerator(ModuleScope, interfaceToProxy) { Logger = Logger };
+        return generator.GenerateCode(interfaceToProxy, null, ProxyGenerationOptions.Default);
+    }
 
-            AssertValidType(interfaceToProxy);
-            var generator = new ServiceHostInterfaceProxyGenerator(ModuleScope, interfaceToProxy) { Logger = Logger };
-            return generator.GenerateCode(interfaceToProxy, null, ProxyGenerationOptions.Default);
+    /// <summary>
+    /// Validates that the target type to proxy is visible and not generic.
+    /// </summary>
+    /// <param name="target">
+    /// The interface type to proxy.
+    /// </param>
+    private static void AssertValidType(Type target)
+    {
+        // This is copied from the DefaultProxyBuilder because we need to
+        // validate types but the validation logic is not accessible.
+        var isTargetNested = target.IsNested;
+        var isNestedAndInternal = isTargetNested && (target.IsNestedAssembly || target.IsNestedFamORAssem);
+        var isInternalNotNested = target.IsVisible == false && isTargetNested == false;
+
+        var internalAndVisibleToDynProxy = (isInternalNotNested || isNestedAndInternal) && ProxyUtil.IsAccessible(target);
+        var isAccessible = target.IsPublic || target.IsNestedPublic || internalAndVisibleToDynProxy;
+
+        if (!isAccessible)
+        {
+            throw new GeneratorException(string.Format(CultureInfo.CurrentCulture, Resources.DynamicProxy_InterfaceTypeToProxyNotPublic, target.FullName));
+        }
+
+        if (target.IsGenericTypeDefinition)
+        {
+            throw new GeneratorException(string.Format(CultureInfo.CurrentCulture, Resources.DynamicProxy_InterfaceTypeToProxyIsGeneric, target.FullName));
         }
     }
 }

--- a/src/Autofac.Multitenant.Wcf/DynamicProxy/ServiceHostProxyGenerator.cs
+++ b/src/Autofac.Multitenant.Wcf/DynamicProxy/ServiceHostProxyGenerator.cs
@@ -1,5 +1,8 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// <copyright file="ServiceHostProxyGenerator.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Autofac.Multitenant.Wcf.DynamicProxy;
 
 using System;
 using System.Globalization;
@@ -9,144 +12,141 @@ using System.ServiceModel.Activation;
 using Autofac.Multitenant.Wcf.Properties;
 using Castle.DynamicProxy;
 
-namespace Autofac.Multitenant.Wcf.DynamicProxy
+/// <summary>
+/// Proxy generator used in multitenant service hosting.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The WCF service host has very specific requirements around the object type that
+/// you pass in when you call <see cref="ServiceHostFactory.CreateServiceHost(Type,Uri[])"/>.
+/// </para>
+/// <para>
+/// If you have a type that has a <see cref="ServiceContractAttribute"/>
+/// on it and it implements an interface that has <see cref="ServiceContractAttribute"/>
+/// on it, the WCF service host complains that you can't have two different
+/// service contracts.
+/// </para>
+/// <para>
+/// The proxy generator uses a <see cref="ServiceHostProxyBuilder"/>
+/// to build the proxy types. This is specifically interesting in the
+/// <see cref="CreateWcfProxy"/> method, which uses some special overrides
+/// and additions in the builder.
+/// </para>
+/// <para>
+/// The builder, when called through <see cref="CreateWcfProxy"/>,
+/// generates proxy types that ignore non-inherited
+/// attributes on the service interface (e.g.,
+/// <see cref="ServiceContractAttribute"/>)
+/// so when the proxy type is generated, it doesn't bring over anything
+/// that will cause WCF host initialization to fail or get confused.
+/// </para>
+/// </remarks>
+[SecurityCritical]
+public class ServiceHostProxyGenerator : ProxyGenerator
 {
     /// <summary>
-    /// Proxy generator used in multitenant service hosting.
+    /// Initializes a new instance of the <see cref="ServiceHostProxyGenerator"/> class.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The WCF service host has very specific requirements around the object type that
-    /// you pass in when you call <see cref="ServiceHostFactory.CreateServiceHost(Type,Uri[])"/>.
-    /// </para>
-    /// <para>
-    /// If you have a type that has a <see cref="ServiceContractAttribute"/>
-    /// on it and it implements an interface that has <see cref="ServiceContractAttribute"/>
-    /// on it, the WCF service host complains that you can't have two different
-    /// service contracts.
-    /// </para>
-    /// <para>
     /// The proxy generator uses a <see cref="ServiceHostProxyBuilder"/>
-    /// to build the proxy types. This is specifically interesting in the
-    /// <see cref="CreateWcfProxy"/> method, which uses some special overrides
-    /// and additions in the builder.
-    /// </para>
-    /// <para>
-    /// The builder, when called through <see cref="CreateWcfProxy"/>,
-    /// generates proxy types that ignore non-inherited
-    /// attributes on the service interface (e.g.,
-    /// <see cref="ServiceContractAttribute"/>)
-    /// so when the proxy type is generated, it doesn't bring over anything
-    /// that will cause WCF host initialization to fail or get confused.
+    /// to build the proxy types.
     /// </para>
     /// </remarks>
-    [SecurityCritical]
-    public class ServiceHostProxyGenerator : ProxyGenerator
+    public ServiceHostProxyGenerator()
+        : base(new ServiceHostProxyBuilder())
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ServiceHostProxyGenerator"/> class.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The proxy generator uses a <see cref="ServiceHostProxyBuilder"/>
-        /// to build the proxy types.
-        /// </para>
-        /// </remarks>
-        public ServiceHostProxyGenerator()
-            : base(new ServiceHostProxyBuilder())
+    }
+
+    /// <summary>
+    /// Creates a proxy object that can be used by the WCF service host.
+    /// </summary>
+    /// <param name="interfaceToProxy">
+    /// The WCF service interface for service implementations.
+    /// </param>
+    /// <param name="target">
+    /// The target of the proxy object that will receive the actual calls.
+    /// </param>
+    /// <returns>
+    /// An object that implements the interface <paramref name="interfaceToProxy" />
+    /// and proxies calls to the <paramref name="target" />.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// When initializing the service host, call this method with a dummy
+    /// <paramref name="target" /> object, just to create the dynamic proxy
+    /// type for the first time and get the service host up and running.
+    /// Subsequent proxies for that interface should have a valid target
+    /// implementation type to which service calls will be proxied.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="interfaceToProxy" /> or <paramref name="target" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <para>
+    /// Thrown if:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>
+    /// <term><paramref name="interfaceToProxy" /> is not an interface.</term>
+    /// </item>
+    /// <item>
+    /// <term><paramref name="interfaceToProxy" /> is an open generic.</term>
+    /// </item>
+    /// <item>
+    /// <term><paramref name="target" /> cannot be cast to <paramref name="interfaceToProxy" />.</term>
+    /// </item>
+    /// </list>
+    /// </exception>
+    public object CreateWcfProxy(Type interfaceToProxy, object target)
+    {
+        if (interfaceToProxy == null)
         {
+            throw new ArgumentNullException(nameof(interfaceToProxy));
         }
 
-        /// <summary>
-        /// Creates a proxy object that can be used by the WCF service host.
-        /// </summary>
-        /// <param name="interfaceToProxy">
-        /// The WCF service interface for service implementations.
-        /// </param>
-        /// <param name="target">
-        /// The target of the proxy object that will receive the actual calls.
-        /// </param>
-        /// <returns>
-        /// An object that implements the interface <paramref name="interfaceToProxy" />
-        /// and proxies calls to the <paramref name="target" />.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// When initializing the service host, call this method with a dummy
-        /// <paramref name="target" /> object, just to create the dynamic proxy
-        /// type for the first time and get the service host up and running.
-        /// Subsequent proxies for that interface should have a valid target
-        /// implementation type to which service calls will be proxied.
-        /// </para>
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="interfaceToProxy" /> or <paramref name="target" /> is <see langword="null" />.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// <para>
-        /// Thrown if:
-        /// </para>
-        /// <list type="bullet">
-        /// <item>
-        /// <term><paramref name="interfaceToProxy" /> is not an interface.</term>
-        /// </item>
-        /// <item>
-        /// <term><paramref name="interfaceToProxy" /> is an open generic.</term>
-        /// </item>
-        /// <item>
-        /// <term><paramref name="target" /> cannot be cast to <paramref name="interfaceToProxy" />.</term>
-        /// </item>
-        /// </list>
-        /// </exception>
-        public object CreateWcfProxy(Type interfaceToProxy, object target)
+        if (!interfaceToProxy.IsInterface)
         {
-            if (interfaceToProxy == null)
-            {
-                throw new ArgumentNullException(nameof(interfaceToProxy));
-            }
-
-            if (!interfaceToProxy.IsInterface)
-            {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.DynamicProxy_InterfaceTypeToProxyNotInterface, interfaceToProxy.FullName), nameof(interfaceToProxy));
-            }
-
-            if (interfaceToProxy.IsGenericTypeDefinition)
-            {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.DynamicProxy_InterfaceTypeToProxyIsGeneric, interfaceToProxy.FullName), nameof(interfaceToProxy));
-            }
-
-            if (target == null)
-            {
-                throw new ArgumentNullException(nameof(target));
-            }
-
-            if (!interfaceToProxy.IsInstanceOfType(target))
-            {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.DynamicProxy_ProxyTargetDoesNotImplementInterface, target.GetType().FullName, interfaceToProxy.FullName), nameof(target));
-            }
-
-            if (interfaceToProxy.GetCustomAttributes(typeof(ServiceContractAttribute), false).Length == 0)
-            {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.DynamicProxy_InterfaceTypeToProxyNotServiceContract, interfaceToProxy.FullName));
-            }
-
-            Type type = this.CreateWcfProxyType(interfaceToProxy);
-            return Activator.CreateInstance(type, Array.Empty<IInterceptor>(), target);
+            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.DynamicProxy_InterfaceTypeToProxyNotInterface, interfaceToProxy.FullName), nameof(interfaceToProxy));
         }
 
-        /// <summary>
-        /// Creates the WCF service interface proxy type or retrieves it from cache.
-        /// </summary>
-        /// <param name="interfaceToProxy">
-        /// The interface type that will be proxied.
-        /// </param>
-        /// <returns>
-        /// A generated proxy type that can be used to proxy calls to actual
-        /// service implementations.
-        /// </returns>
-        protected virtual Type CreateWcfProxyType(Type interfaceToProxy)
+        if (interfaceToProxy.IsGenericTypeDefinition)
         {
-            return ((ServiceHostProxyBuilder)this.ProxyBuilder).CreateWcfProxyType(interfaceToProxy);
+            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.DynamicProxy_InterfaceTypeToProxyIsGeneric, interfaceToProxy.FullName), nameof(interfaceToProxy));
         }
+
+        if (target == null)
+        {
+            throw new ArgumentNullException(nameof(target));
+        }
+
+        if (!interfaceToProxy.IsInstanceOfType(target))
+        {
+            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.DynamicProxy_ProxyTargetDoesNotImplementInterface, target.GetType().FullName, interfaceToProxy.FullName), nameof(target));
+        }
+
+        if (interfaceToProxy.GetCustomAttributes(typeof(ServiceContractAttribute), false).Length == 0)
+        {
+            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.DynamicProxy_InterfaceTypeToProxyNotServiceContract, interfaceToProxy.FullName));
+        }
+
+        var type = this.CreateWcfProxyType(interfaceToProxy);
+        return Activator.CreateInstance(type, Array.Empty<IInterceptor>(), target);
+    }
+
+    /// <summary>
+    /// Creates the WCF service interface proxy type or retrieves it from cache.
+    /// </summary>
+    /// <param name="interfaceToProxy">
+    /// The interface type that will be proxied.
+    /// </param>
+    /// <returns>
+    /// A generated proxy type that can be used to proxy calls to actual
+    /// service implementations.
+    /// </returns>
+    protected virtual Type CreateWcfProxyType(Type interfaceToProxy)
+    {
+        return ((ServiceHostProxyBuilder)this.ProxyBuilder).CreateWcfProxyType(interfaceToProxy);
     }
 }

--- a/src/Autofac.Multitenant.Wcf/DynamicProxy/TypeExtensions.cs
+++ b/src/Autofac.Multitenant.Wcf/DynamicProxy/TypeExtensions.cs
@@ -1,34 +1,34 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// <copyright file="TypeExtensions.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Autofac.Multitenant.Wcf.DynamicProxy;
 
 using System;
 
-namespace Autofac.Multitenant.Wcf.DynamicProxy
+/// <summary>
+/// Extension methods for the <see cref="Type"/> class.
+/// </summary>
+public static class TypeExtensions
 {
     /// <summary>
-    /// Extension methods for the <see cref="Type"/> class.
+    /// Gets the metadata buddy class type, if any, as marked by a
+    /// <see cref="ServiceMetadataTypeAttribute"/>.
     /// </summary>
-    public static class TypeExtensions
+    /// <param name="interfaceType">The service interface type from which to retrieve the metadata class.</param>
+    /// <returns>
+    /// The metadata type for the service interface as specified by a
+    /// <see cref="ServiceMetadataTypeAttribute"/>,
+    /// if it exists; otherwise <see langword="null" />.
+    /// </returns>
+    public static Type GetMetadataClassType(this Type interfaceType)
     {
-        /// <summary>
-        /// Gets the metadata buddy class type, if any, as marked by a
-        /// <see cref="ServiceMetadataTypeAttribute"/>.
-        /// </summary>
-        /// <param name="interfaceType">The service interface type from which to retrieve the metadata class.</param>
-        /// <returns>
-        /// The metadata type for the service interface as specified by a
-        /// <see cref="ServiceMetadataTypeAttribute"/>,
-        /// if it exists; otherwise <see langword="null" />.
-        /// </returns>
-        public static Type GetMetadataClassType(this Type interfaceType)
+        if (interfaceType == null)
         {
-            if (interfaceType == null)
-            {
-                throw new ArgumentNullException(nameof(interfaceType));
-            }
-
-            var attributes = (ServiceMetadataTypeAttribute[])interfaceType.GetCustomAttributes(typeof(ServiceMetadataTypeAttribute), false);
-            return attributes.Length == 0 ? null : attributes[0].MetadataClassType;
+            throw new ArgumentNullException(nameof(interfaceType));
         }
+
+        var attributes = (ServiceMetadataTypeAttribute[])interfaceType.GetCustomAttributes(typeof(ServiceMetadataTypeAttribute), false);
+        return attributes.Length == 0 ? null : attributes[0].MetadataClassType;
     }
 }

--- a/src/Autofac.Multitenant.Wcf/MultitenantServiceImplementationDataProvider.cs
+++ b/src/Autofac.Multitenant.Wcf/MultitenantServiceImplementationDataProvider.cs
@@ -1,5 +1,8 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// <copyright file="MultitenantServiceImplementationDataProvider.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Autofac.Multitenant.Wcf;
 
 using System;
 using System.Globalization;
@@ -9,111 +12,104 @@ using Autofac.Integration.Wcf;
 using Autofac.Multitenant.Wcf.DynamicProxy;
 using Autofac.Multitenant.Wcf.Properties;
 
-namespace Autofac.Multitenant.Wcf
+/// <summary>
+/// Service implementation data provider that returns multitenant-aware
+/// service hosting information.
+/// </summary>
+[SecurityCritical]
+public class MultitenantServiceImplementationDataProvider : IServiceImplementationDataProvider
 {
     /// <summary>
-    /// Service implementation data provider that returns multitenant-aware
-    /// service hosting information.
+    /// Proxy generator used to create proxy types that will be substituted
+    /// in during service hosting.
     /// </summary>
-    [SecurityCritical]
-    public class MultitenantServiceImplementationDataProvider : IServiceImplementationDataProvider
+    private static readonly ServiceHostProxyGenerator _generator = new ServiceHostProxyGenerator();
+
+    /// <summary>
+    /// Gets data about a service implementation.
+    /// </summary>
+    /// <param name="value">
+    /// The constructor string passed in to the service host factory
+    /// that is used to determine which type to host/use as a service
+    /// implementation.
+    /// </param>
+    /// <returns>
+    /// A <see cref="ServiceImplementationData"/>
+    /// object containing information about which type to use in
+    /// the service host and how to resolve the implementation.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// This method returns a dynamic proxy object as the type to host
+    /// and resolves the implementation type as a dynamic proxy that proxies
+    /// to a tenant-specific implementation. This is necessary since
+    /// WCF will only allow hosting of concrete classes and we need it to,
+    /// effectively, host an 'interface' - in this case, a dynamic proxy type
+    /// rather than an actual implementation type.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="value" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if <paramref name="value" /> is empty.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if <paramref name="value" /> does not resolve into
+    /// a known type, resolves to a type that is not an interface, or the
+    /// interface it resolves to is not marked with a <see cref="ServiceContractAttribute"/>.
+    /// </exception>
+    public ServiceImplementationData GetServiceImplementationData(string value)
     {
-        /// <summary>
-        /// Proxy generator used to create proxy types that will be substituted
-        /// in during service hosting.
-        /// </summary>
-        private static readonly ServiceHostProxyGenerator Generator = new ServiceHostProxyGenerator();
-
-        /// <summary>
-        /// Gets data about a service implementation.
-        /// </summary>
-        /// <param name="value">
-        /// The constructor string passed in to the service host factory
-        /// that is used to determine which type to host/use as a service
-        /// implementation.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ServiceImplementationData"/>
-        /// object containing information about which type to use in
-        /// the service host and how to resolve the implementation.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// This method returns a dynamic proxy object as the type to host
-        /// and resolves the implementation type as a dynamic proxy that proxies
-        /// to a tenant-specific implementation. This is necessary since
-        /// WCF will only allow hosting of concrete classes and we need it to,
-        /// effectively, host an 'interface' - in this case, a dynamic proxy type
-        /// rather than an actual implementation type.
-        /// </para>
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="value" /> is <see langword="null" />.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// Thrown if <paramref name="value" /> is empty.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if <paramref name="value" /> does not resolve into
-        /// a known type, resolves to a type that is not an interface, or the
-        /// interface it resolves to is not marked with a <see cref="ServiceContractAttribute"/>.
-        /// </exception>
-        public ServiceImplementationData GetServiceImplementationData(string value)
+        if (value == null)
         {
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            if (value.Length == 0)
-            {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.ArgumentException_StringEmpty, nameof(value)));
-            }
-
-            Type serviceInterfaceType = Type.GetType(value, false);
-            if (serviceInterfaceType == null)
-            {
-                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.MultitenantServiceImplementationDataProvider_ServiceInterfaceTypeNotResolvable, value));
-            }
-
-            if (!serviceInterfaceType.IsInterface)
-            {
-                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.MultitenantServiceImplementationDataProvider_ServiceInterfaceTypeNotInterface, value, serviceInterfaceType));
-            }
-
-            if (serviceInterfaceType.GetCustomAttributes(typeof(ServiceContractAttribute), false).Length == 0)
-            {
-                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.MultitenantServiceImplementationDataProvider_ServiceInterfaceTypeNotServiceContract, value, serviceInterfaceType));
-            }
-
-            // To create the actual proxy object type that will be used to sub-in
-            // tenant-specific instances, we need to create a dummy implementation
-            // (which is an empty proxy without a target) and then a real proxy
-            // (which will use that dummy as a target). The reason is that Castle
-            // generates two different proxy types when this happens - the first
-            // proxy type - the dummy object - will be something like "Castle.Proxies.ProxyType"
-            // and the second proxy type - the one with a target - will be
-            // something like "Castle.Proxies.ProxyType_1". Subsequent proxies
-            // created for the same interface type that have a target will be
-            // of the same type as the original - "Castle.Proxies.ProxyType_1"
-            // (or whatever) because Castle caches the various proxy type definitions.
-            var dummyHostProxyObject = Generator.CreateInterfaceProxyWithoutTarget(serviceInterfaceType);
-            var actualHostProxyObject = Generator.CreateWcfProxy(serviceInterfaceType, dummyHostProxyObject);
-
-            return new ServiceImplementationData
-            {
-                ConstructorString = value,
-                ServiceTypeToHost = actualHostProxyObject.GetType(),
-                ImplementationResolver = l =>
-                {
-                    var implementation = l.Resolve(serviceInterfaceType);
-
-                    // The wrapped implementation will be of the same proxy
-                    // type as "actualHostProxyObject" above.
-                    var implementationProxy = Generator.CreateWcfProxy(serviceInterfaceType, implementation);
-                    return implementationProxy;
-                },
-            };
+            throw new ArgumentNullException(nameof(value));
         }
+
+        if (value.Length == 0)
+        {
+            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.ArgumentException_StringEmpty, nameof(value)));
+        }
+
+        var serviceInterfaceType = Type.GetType(value, false) ?? throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.MultitenantServiceImplementationDataProvider_ServiceInterfaceTypeNotResolvable, value));
+
+        if (!serviceInterfaceType.IsInterface)
+        {
+            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.MultitenantServiceImplementationDataProvider_ServiceInterfaceTypeNotInterface, value, serviceInterfaceType));
+        }
+
+        if (serviceInterfaceType.GetCustomAttributes(typeof(ServiceContractAttribute), false).Length == 0)
+        {
+            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.MultitenantServiceImplementationDataProvider_ServiceInterfaceTypeNotServiceContract, value, serviceInterfaceType));
+        }
+
+        // To create the actual proxy object type that will be used to sub-in
+        // tenant-specific instances, we need to create a dummy implementation
+        // (which is an empty proxy without a target) and then a real proxy
+        // (which will use that dummy as a target). The reason is that Castle
+        // generates two different proxy types when this happens - the first
+        // proxy type - the dummy object - will be something like "Castle.Proxies.ProxyType"
+        // and the second proxy type - the one with a target - will be
+        // something like "Castle.Proxies.ProxyType_1". Subsequent proxies
+        // created for the same interface type that have a target will be
+        // of the same type as the original - "Castle.Proxies.ProxyType_1"
+        // (or whatever) because Castle caches the various proxy type definitions.
+        var dummyHostProxyObject = _generator.CreateInterfaceProxyWithoutTarget(serviceInterfaceType);
+        var actualHostProxyObject = _generator.CreateWcfProxy(serviceInterfaceType, dummyHostProxyObject);
+
+        return new ServiceImplementationData
+        {
+            ConstructorString = value,
+            ServiceTypeToHost = actualHostProxyObject.GetType(),
+            ImplementationResolver = l =>
+            {
+                var implementation = l.Resolve(serviceInterfaceType);
+
+                // The wrapped implementation will be of the same proxy
+                // type as "actualHostProxyObject" above.
+                var implementationProxy = _generator.CreateWcfProxy(serviceInterfaceType, implementation);
+                return implementationProxy;
+            },
+        };
     }
 }

--- a/src/Autofac.Multitenant.Wcf/OperationContextTenantIdentificationStrategy.cs
+++ b/src/Autofac.Multitenant.Wcf/OperationContextTenantIdentificationStrategy.cs
@@ -1,71 +1,71 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// <copyright file="OperationContextTenantIdentificationStrategy.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Autofac.Multitenant.Wcf;
 
 using System.Linq;
 using System.ServiceModel;
 
-namespace Autofac.Multitenant.Wcf
+/// <summary>
+/// An <see cref="ITenantIdentificationStrategy"/>
+/// implementation that gets the tenant ID from a <see cref="TenantIdentificationContextExtension"/>
+/// attached to the current <see cref="OperationContext"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use this <see cref="ITenantIdentificationStrategy"/>
+/// if you are using the <see cref="TenantIdentificationContextExtension"/>
+/// as the mechanism for tracking which tenant a given operation is running
+/// under.
+/// </para>
+/// <para>
+/// For example, you could use an <see cref="System.ServiceModel.Dispatcher.IDispatchMessageInspector"/>
+/// that gets the tenant ID from an incoming header and adds a
+/// <see cref="TenantIdentificationContextExtension"/>
+/// to the current <see cref="OperationContext"/> with
+/// the tenant ID value. Then you could register this provider as the
+/// mechanism for determining the tenant ID when resolving multitenant dependencies.
+/// </para>
+/// <para>
+/// The <see cref="TenantPropagationBehavior{TTenantId}"/>
+/// does exactly that - adds the tenant ID to outbound messages on the client
+/// and parses them on the service side. For a usage example, see
+/// <see cref="TenantPropagationBehavior{TTenantId}"/>.
+/// </para>
+/// </remarks>
+/// <seealso cref="TenantIdentificationContextExtension"/>
+/// <seealso cref="TenantPropagationBehavior{TTenantId}"/>
+public class OperationContextTenantIdentificationStrategy : ITenantIdentificationStrategy
 {
     /// <summary>
-    /// An <see cref="ITenantIdentificationStrategy"/>
-    /// implementation that gets the tenant ID from a <see cref="TenantIdentificationContextExtension"/>
-    /// attached to the current <see cref="OperationContext"/>.
+    /// Attempts to identify the tenant from the current operation context.
     /// </summary>
+    /// <param name="tenantId">The current tenant identifier.</param>
+    /// <returns>
+    /// <see langword="true"/> if the tenant could be identified; <see langword="false"/>
+    /// if not.
+    /// </returns>
     /// <remarks>
     /// <para>
-    /// Use this <see cref="ITenantIdentificationStrategy"/>
-    /// if you are using the <see cref="TenantIdentificationContextExtension"/>
-    /// as the mechanism for tracking which tenant a given operation is running
-    /// under.
-    /// </para>
-    /// <para>
-    /// For example, you could use an <see cref="System.ServiceModel.Dispatcher.IDispatchMessageInspector"/>
-    /// that gets the tenant ID from an incoming header and adds a
+    /// The <paramref name="tenantId" /> will be the <see cref="object"/> value from the first
     /// <see cref="TenantIdentificationContextExtension"/>
-    /// to the current <see cref="OperationContext"/> with
-    /// the tenant ID value. Then you could register this provider as the
-    /// mechanism for determining the tenant ID when resolving multitenant dependencies.
-    /// </para>
-    /// <para>
-    /// The <see cref="TenantPropagationBehavior{TTenantId}"/>
-    /// does exactly that - adds the tenant ID to outbound messages on the client
-    /// and parses them on the service side. For a usage example, see
-    /// <see cref="TenantPropagationBehavior{TTenantId}"/>.
+    /// found on the current <see cref="OperationContext"/>,
+    /// or <see langword="null" /> if there is no extension found on the
+    /// operation context.
     /// </para>
     /// </remarks>
-    /// <seealso cref="TenantIdentificationContextExtension"/>
-    /// <seealso cref="TenantPropagationBehavior{TTenantId}"/>
-    public class OperationContextTenantIdentificationStrategy : ITenantIdentificationStrategy
+    public bool TryIdentifyTenant(out object tenantId)
     {
-        /// <summary>
-        /// Attempts to identify the tenant from the current operation context.
-        /// </summary>
-        /// <param name="tenantId">The current tenant identifier.</param>
-        /// <returns>
-        /// <see langword="true"/> if the tenant could be identified; <see langword="false"/>
-        /// if not.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// The <paramref name="tenantId" /> will be the <see cref="object"/> value from the first
-        /// <see cref="TenantIdentificationContextExtension"/>
-        /// found on the current <see cref="OperationContext"/>,
-        /// or <see langword="null" /> if there is no extension found on the
-        /// operation context.
-        /// </para>
-        /// </remarks>
-        public bool TryIdentifyTenant(out object tenantId)
+        tenantId = null;
+        var context = OperationContext.Current;
+        var extension = context?.Extensions.OfType<TenantIdentificationContextExtension>().FirstOrDefault();
+        if (extension == null)
         {
-            tenantId = null;
-            var context = OperationContext.Current;
-            var extension = context?.Extensions.OfType<TenantIdentificationContextExtension>().FirstOrDefault();
-            if (extension == null)
-            {
-                return false;
-            }
-
-            tenantId = extension.TenantId;
-            return true;
+            return false;
         }
+
+        tenantId = extension.TenantId;
+        return true;
     }
 }

--- a/src/Autofac.Multitenant.Wcf/Properties/AssemblyInfo.cs
+++ b/src/Autofac.Multitenant.Wcf/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// <copyright file="AssemblyInfo.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Autofac.Multitenant.Wcf/ServiceMetadataTypeAttribute.cs
+++ b/src/Autofac.Multitenant.Wcf/ServiceMetadataTypeAttribute.cs
@@ -1,73 +1,71 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// <copyright file="ServiceMetadataTypeAttribute.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Autofac.Multitenant.Wcf;
 
 using System;
 using System.ServiceModel;
 using Autofac.Integration.Wcf;
 
-namespace Autofac.Multitenant.Wcf
+/// <summary>
+/// Specifies the metadata class to associate with a service implementation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When hosting a service in a multitenant environment using <see cref="AutofacHostFactory"/>
+/// and the dynamic proxy generation that occurs therein, you can't really
+/// mark your "service implementation class" with metadata attributes like
+/// the <see cref="ServiceBehaviorAttribute"/>. Also,
+/// since many of these attributes require you to mark a class rather than
+/// the service interface, there's no way to otherwise specify them.
+/// </para>
+/// <para>
+/// This attribute works similar to the <c>System.ComponentModel.DataAnnotations.MetadataTypeAttribute</c>
+/// and allows you to mark a service interface such that the generated dynamic
+/// proxy class will use a "metadata buddy class" to retrieve various attributes
+/// that should be applied during generation.
+/// </para>
+/// <para>
+/// Mark your service interface with one of these attributes, then create an
+/// empty class with the <see cref="ServiceBehaviorAttribute"/>
+/// (or whatever) associated with it. The dynamic proxy generation will copy
+/// these attributes, thus allowing you to still make use of service metadata info.
+/// </para>
+/// <para>
+/// This is particularly handy when choosing to specify a service name. Since
+/// WCF usually infers the service name (which is also the name of the service
+/// element in configuration that it uses to set up the service host) from the
+/// type of the implementation, a dynamic proxy implementation results in
+/// service names like <c>Castle.Proxies.IMyServiceProxy_1</c>. To manually
+/// specify the name, you use the <see cref="ServiceBehaviorAttribute.Name"/>
+/// property, which can be associated with a service metadata buddy class.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Interface)]
+public sealed class ServiceMetadataTypeAttribute : Attribute
 {
     /// <summary>
-    /// Specifies the metadata class to associate with a service implementation.
+    /// Initializes a new instance of the <see cref="ServiceMetadataTypeAttribute"/> class.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// When hosting a service in a multitenant environment using <see cref="AutofacHostFactory"/>
-    /// and the dynamic proxy generation that occurs therein, you can't really
-    /// mark your "service implementation class" with metadata attributes like
-    /// the <see cref="ServiceBehaviorAttribute"/>. Also,
-    /// since many of these attributes require you to mark a class rather than
-    /// the service interface, there's no way to otherwise specify them.
-    /// </para>
-    /// <para>
-    /// This attribute works similar to the <c>System.ComponentModel.DataAnnotations.MetadataTypeAttribute</c>
-    /// and allows you to mark a service interface such that the generated dynamic
-    /// proxy class will use a "metadata buddy class" to retrieve various attributes
-    /// that should be applied during generation.
-    /// </para>
-    /// <para>
-    /// Mark your service interface with one of these attributes, then create an
-    /// empty class with the <see cref="ServiceBehaviorAttribute"/>
-    /// (or whatever) associated with it. The dynamic proxy generation will copy
-    /// these attributes, thus allowing you to still make use of service metadata info.
-    /// </para>
-    /// <para>
-    /// This is particularly handy when choosing to specify a service name. Since
-    /// WCF usually infers the service name (which is also the name of the service
-    /// element in configuration that it uses to set up the service host) from the
-    /// type of the implementation, a dynamic proxy implementation results in
-    /// service names like <c>Castle.Proxies.IMyServiceProxy_1</c>. To manually
-    /// specify the name, you use the <see cref="ServiceBehaviorAttribute.Name"/>
-    /// property, which can be associated with a service metadata buddy class.
-    /// </para>
-    /// </remarks>
-    [AttributeUsage(AttributeTargets.Interface)]
-    public sealed class ServiceMetadataTypeAttribute : Attribute
+    /// <param name="metadataClassType">The metadata class type for specifying service metadata.</param>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="metadataClassType" /> is <see langword="null" />.
+    /// </exception>
+    public ServiceMetadataTypeAttribute(Type metadataClassType)
     {
-        /// <summary>
-        /// Gets the metadata class type.
-        /// </summary>
-        /// <value>
-        /// A <see cref="Type"/> indicating the class to be used to
-        /// gather metadata for the service implementation proxy.
-        /// </value>
-        public Type MetadataClassType { get; }
+        this.MetadataClassType = metadataClassType ?? throw new ArgumentNullException(nameof(metadataClassType));
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ServiceMetadataTypeAttribute"/> class.
-        /// </summary>
-        /// <param name="metadataClassType">The metadata class type for specifying service metadata.</param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="metadataClassType" /> is <see langword="null" />.
-        /// </exception>
-        public ServiceMetadataTypeAttribute(Type metadataClassType)
-        {
-            if (metadataClassType == null)
-            {
-                throw new ArgumentNullException(nameof(metadataClassType));
-            }
-
-            this.MetadataClassType = metadataClassType;
-        }
+    /// <summary>
+    /// Gets the metadata class type.
+    /// </summary>
+    /// <value>
+    /// A <see cref="Type"/> indicating the class to be used to
+    /// gather metadata for the service implementation proxy.
+    /// </value>
+    public Type MetadataClassType
+    {
+        get;
     }
 }

--- a/src/Autofac.Multitenant.Wcf/TenantIdentificationContextExtension.cs
+++ b/src/Autofac.Multitenant.Wcf/TenantIdentificationContextExtension.cs
@@ -1,67 +1,70 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// <copyright file="TenantIdentificationContextExtension.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Autofac.Multitenant.Wcf;
 
 using System.ServiceModel;
 
-namespace Autofac.Multitenant.Wcf
+/// <summary>
+/// Extension for <see cref="OperationContext"/>
+/// that allows propagation of the tenant ID.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use this extension in conjunction with the
+/// <see cref="OperationContextTenantIdentificationStrategy"/>
+/// to determine which tenant a given operation is running under.
+/// </para>
+/// <para>
+/// For example, you could use an <see cref="System.ServiceModel.Dispatcher.IDispatchMessageInspector"/>
+/// that gets the tenant ID from an incoming header and adds a
+/// <see cref="TenantIdentificationContextExtension"/>
+/// to the current <see cref="OperationContext"/> with
+/// the tenant ID value. Then you could register the
+/// <see cref="OperationContextTenantIdentificationStrategy"/>
+/// as the mechanism for determining the tenant ID when resolving multitenant dependencies.
+/// </para>
+/// <para>
+/// The <see cref="TenantPropagationBehavior{TTenantId}"/>
+/// is a behavior that does exactly that - adds the tenant ID to outbound messages on the client
+/// and parses them on the service side. For a usage example, see
+/// <see cref="TenantPropagationBehavior{TTenantId}"/>.
+/// </para>
+/// </remarks>
+/// <seealso cref="OperationContextTenantIdentificationStrategy"/>
+/// <seealso cref="TenantPropagationBehavior{TTenantId}"/>
+public class TenantIdentificationContextExtension : IExtension<OperationContext>
 {
     /// <summary>
-    /// Extension for <see cref="OperationContext"/>
-    /// that allows propagation of the tenant ID.
+    /// Gets or sets the tenant ID.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Use this extension in conjunction with the
-    /// <see cref="OperationContextTenantIdentificationStrategy"/>
-    /// to determine which tenant a given operation is running under.
-    /// </para>
-    /// <para>
-    /// For example, you could use an <see cref="System.ServiceModel.Dispatcher.IDispatchMessageInspector"/>
-    /// that gets the tenant ID from an incoming header and adds a
-    /// <see cref="TenantIdentificationContextExtension"/>
-    /// to the current <see cref="OperationContext"/> with
-    /// the tenant ID value. Then you could register the
-    /// <see cref="OperationContextTenantIdentificationStrategy"/>
-    /// as the mechanism for determining the tenant ID when resolving multitenant dependencies.
-    /// </para>
-    /// <para>
-    /// The <see cref="TenantPropagationBehavior{TTenantId}"/>
-    /// is a behavior that does exactly that - adds the tenant ID to outbound messages on the client
-    /// and parses them on the service side. For a usage example, see
-    /// <see cref="TenantPropagationBehavior{TTenantId}"/>.
-    /// </para>
-    /// </remarks>
-    /// <seealso cref="OperationContextTenantIdentificationStrategy"/>
-    /// <seealso cref="TenantPropagationBehavior{TTenantId}"/>
-    public class TenantIdentificationContextExtension : IExtension<OperationContext>
+    /// <value>
+    /// An <see cref="object"/> that uniquely identifies the tenant
+    /// under which the current operation is executing.
+    /// </value>
+    public object TenantId
     {
-        /// <summary>
-        /// Gets or sets the tenant ID.
-        /// </summary>
-        /// <value>
-        /// An <see cref="object"/> that uniquely identifies the tenant
-        /// under which the current operation is executing.
-        /// </value>
-        public object TenantId { get; set; }
+        get; set;
+    }
 
-        /// <summary>
-        /// Enables an extension object to find out when it has been aggregated.
-        /// </summary>
-        /// <param name="owner">
-        /// The extensible object that aggregates this extension.
-        /// </param>
-        public virtual void Attach(OperationContext owner)
-        {
-        }
+    /// <summary>
+    /// Enables an extension object to find out when it has been aggregated.
+    /// </summary>
+    /// <param name="owner">
+    /// The extensible object that aggregates this extension.
+    /// </param>
+    public virtual void Attach(OperationContext owner)
+    {
+    }
 
-        /// <summary>
-        /// Enables an object to find out when it is no longer aggregated.
-        /// </summary>
-        /// <param name="owner">
-        /// The extensible object that aggregates this extension.
-        /// </param>
-        public virtual void Detach(OperationContext owner)
-        {
-        }
+    /// <summary>
+    /// Enables an object to find out when it is no longer aggregated.
+    /// </summary>
+    /// <param name="owner">
+    /// The extensible object that aggregates this extension.
+    /// </param>
+    public virtual void Detach(OperationContext owner)
+    {
     }
 }

--- a/src/Autofac.Multitenant.Wcf/TenantPropagationBehavior.cs
+++ b/src/Autofac.Multitenant.Wcf/TenantPropagationBehavior.cs
@@ -1,5 +1,8 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// <copyright file="TenantPropagationBehavior.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Autofac.Multitenant.Wcf;
 
 using System;
 using System.Collections.ObjectModel;
@@ -8,271 +11,266 @@ using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
 
-namespace Autofac.Multitenant.Wcf
+/// <summary>
+/// Behavior for WCF clients and service hosts that is used to propagate
+/// tenant ID from client to service.
+/// </summary>
+/// <typeparam name="TTenantId">
+/// The type of the tenant ID to propagate. Must be nullable and
+/// serializable so it can be added to a message header.
+/// </typeparam>
+/// <remarks>
+/// <para>
+/// This behavior applies the <see cref="TenantPropagationMessageInspector{TTenantId}"/>
+/// to WCF clients and service hosts to automatically get the tenant ID on
+/// the WCF client end, add the ID to a header on the outbound message, and
+/// have the tenant ID read from headers on the service side and added to the
+/// operation context in an
+/// <see cref="TenantIdentificationContextExtension"/>.
+/// This allows you, on the service side, to use the
+/// <see cref="OperationContextTenantIdentificationStrategy"/>
+/// as your registered <see cref="ITenantIdentificationStrategy"/>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <para>
+/// In the following examples, the tenant ID is a <see cref="string"/>,
+/// so the <typeparamref name="TTenantId"/> in the examples corresponds.
+/// In your application, your tenant ID may be a nullable GUID or some other
+/// object, so you'd need to update accordingly. That would mean passing
+/// a different type as <typeparamref name="TTenantId"/> and implementing
+/// a custom <see cref="ITenantIdentificationStrategy"/>
+/// that parses the appropriate tenant ID from the execution context.
+/// </para>
+/// <para>
+/// The following snippet shows what registration of this behavior
+/// might look like in an ASP.NET application that consumes WCF services.
+/// </para>
+/// <code lang="C#">
+/// public class MvcApplication : HttpApplication, IContainerProviderAccessor
+/// {
+///   private static IContainerProvider _containerProvider;
+///
+///   public IContainerProvider ContainerProvider
+///   {
+///     get { return _containerProvider; }
+///   }
+///
+///   public static void RegisterRoutes(RouteCollection routes)
+///   {
+///     // Register your routes as normal.
+///   }
+///
+///   protected void Application_Start()
+///   {
+///     // Create a tenant ID strategy that will get the tenant from
+///     // your ASP.NET request context.
+///     var tenantIdStrategy = new RequestParameterTenantIdentificationStrategy("tenant");
+///
+///     // Register application-level dependencies and controllers.
+///     var builder = new ContainerBuilder();
+///     builder.RegisterType&lt;HomeController&gt;();
+///     // ... and so on.
+///
+///     // When you register the WCF service client, add the
+///     // TenantPropagationBehavior to the Opening event:
+///
+///     builder.Register(
+///       c =&gt; new ChannelFactory&lt;IMultitenantService&gt;(
+///         new BasicHttpBinding(),
+///         new EndpointAddress("http://server/TheService.svc"))).SingleInstance();
+///     builder.Register(
+///       c =&gt;
+///       {
+///         var factory = c.Resolve&lt;ChannelFactory&lt;IMultitenantService&gt;&gt;();
+///         factory.Opening +=
+///           (sender, args) =&gt;
+///             factory.Endpoint.Behaviors.Add(
+///             new TenantPropagationBehavior&lt;string&gt;(tenantIdStrategy);
+///         return factory.CreateChannel()
+///       }).InstancePerHttpRequest();
+///
+///     // Create the multitenant container.
+///     var mtc = new MultitenantContainer(tenantIdStrategy, builder.Build());
+///
+///     // Register tenant specific overrides and set up the
+///     // application container provider.
+///     _containerProvider = new ContainerProvider(mtc);
+///
+///     // Do other MVC setup like route registration, etc.
+///     ControllerBuilder.Current.SetControllerFactory(new AutofacControllerFactory(this.ContainerProvider));
+///     AreaRegistration.RegisterAllAreas();
+///     RegisterRoutes(RouteTable.Routes);
+///   }
+/// }
+/// </code>
+/// <para>
+/// Note that much of the above code is the standard ASP.NET application
+/// wireup with Autofac. The important part is when you register the service
+/// client - it needs to have a <see cref="TenantPropagationBehavior{TTenantId}"/>
+/// attached to it that can get the container provider from the
+/// current application.
+/// </para>
+/// <para>
+/// The following snippet shows what registration of this behavior
+/// looks like in a WCF application hosted in IIS:
+/// </para>
+/// <code lang="C#">
+/// public class Global : System.Web.HttpApplication
+/// {
+///   protected void Application_Start(object sender, EventArgs e)
+///   {
+///       // Create the tenant ID strategy. Required for multitenant integration.
+///       var tenantIdStrategy = new OperationContextTenantIdentificationStrategy();
+///
+///       // Register application-level dependencies and service implementations.
+///       var builder = new ContainerBuilder();
+///       builder.RegisterType&lt;BaseImplementation&gt;().As&lt;IMultitenantService&gt;();
+///       // ... and so on.
+///
+///       // Create the multitenant container.
+///       var mtc = new MultitenantContainer(tenantIdStrategy, builder.Build());
+///
+///       // Configure tenant-specific overrides and set the WCF host container.
+///       Autofac.Multitenant.Wcf.AutofacHostFactory.Container = mtc;
+///
+///       // Add a behavior to service hosts that get created so incoming messages
+///       // get inspected and the tenant ID can be parsed from message headers.
+///       Autofac.Multitenant.Wcf.AutofacHostFactory.HostConfigurationAction =
+///         host =&gt;
+///           host.Opening += (s, args) =&gt;
+///             host.Description.Behaviors.Add(new TenantPropagationBehavior&lt;string&gt;(tenantIdStrategy));
+///   }
+/// }
+/// </code>
+/// <para>
+/// Note that it is also very similar to standard wireup with Autofac WCF
+/// integration, just that you use the multitenant WCF host, a multitenant
+/// container, and a behavior to get the tenant ID from the operation context.
+/// </para>
+/// </example>
+/// <seealso cref="TenantPropagationMessageInspector{TTenantId}"/>
+/// <seealso cref="OperationContextTenantIdentificationStrategy"/>
+public class TenantPropagationBehavior<TTenantId> : IServiceBehavior, IEndpointBehavior
 {
     /// <summary>
-    /// Behavior for WCF clients and service hosts that is used to propagate
-    /// tenant ID from client to service.
+    /// Initializes a new instance of the
+    /// <see cref="TenantPropagationBehavior{TTenantId}"/> class.
     /// </summary>
-    /// <typeparam name="TTenantId">
-    /// The type of the tenant ID to propagate. Must be nullable and
-    /// serializable so it can be added to a message header.
-    /// </typeparam>
-    /// <remarks>
-    /// <para>
-    /// This behavior applies the <see cref="TenantPropagationMessageInspector{TTenantId}"/>
-    /// to WCF clients and service hosts to automatically get the tenant ID on
-    /// the WCF client end, add the ID to a header on the outbound message, and
-    /// have the tenant ID read from headers on the service side and added to the
-    /// operation context in an
-    /// <see cref="TenantIdentificationContextExtension"/>.
-    /// This allows you, on the service side, to use the
-    /// <see cref="OperationContextTenantIdentificationStrategy"/>
-    /// as your registered <see cref="ITenantIdentificationStrategy"/>.
-    /// </para>
-    /// </remarks>
-    /// <example>
-    /// <para>
-    /// In the following examples, the tenant ID is a <see cref="string"/>,
-    /// so the <typeparamref name="TTenantId"/> in the examples corresponds.
-    /// In your application, your tenant ID may be a nullable GUID or some other
-    /// object, so you'd need to update accordingly. That would mean passing
-    /// a different type as <typeparamref name="TTenantId"/> and implementing
-    /// a custom <see cref="ITenantIdentificationStrategy"/>
-    /// that parses the appropriate tenant ID from the execution context.
-    /// </para>
-    /// <para>
-    /// The following snippet shows what registration of this behavior
-    /// might look like in an ASP.NET application that consumes WCF services.
-    /// </para>
-    /// <code lang="C#">
-    /// public class MvcApplication : HttpApplication, IContainerProviderAccessor
-    /// {
-    ///   private static IContainerProvider _containerProvider;
-    ///
-    ///   public IContainerProvider ContainerProvider
-    ///   {
-    ///     get { return _containerProvider; }
-    ///   }
-    ///
-    ///   public static void RegisterRoutes(RouteCollection routes)
-    ///   {
-    ///     // Register your routes as normal.
-    ///   }
-    ///
-    ///   protected void Application_Start()
-    ///   {
-    ///     // Create a tenant ID strategy that will get the tenant from
-    ///     // your ASP.NET request context.
-    ///     var tenantIdStrategy = new RequestParameterTenantIdentificationStrategy("tenant");
-    ///
-    ///     // Register application-level dependencies and controllers.
-    ///     var builder = new ContainerBuilder();
-    ///     builder.RegisterType&lt;HomeController&gt;();
-    ///     // ... and so on.
-    ///
-    ///     // When you register the WCF service client, add the
-    ///     // TenantPropagationBehavior to the Opening event:
-    ///
-    ///     builder.Register(
-    ///       c =&gt; new ChannelFactory&lt;IMultitenantService&gt;(
-    ///         new BasicHttpBinding(),
-    ///         new EndpointAddress("http://server/TheService.svc"))).SingleInstance();
-    ///     builder.Register(
-    ///       c =&gt;
-    ///       {
-    ///         var factory = c.Resolve&lt;ChannelFactory&lt;IMultitenantService&gt;&gt;();
-    ///         factory.Opening +=
-    ///           (sender, args) =&gt;
-    ///             factory.Endpoint.Behaviors.Add(
-    ///             new TenantPropagationBehavior&lt;string&gt;(tenantIdStrategy);
-    ///         return factory.CreateChannel()
-    ///       }).InstancePerHttpRequest();
-    ///
-    ///     // Create the multitenant container.
-    ///     var mtc = new MultitenantContainer(tenantIdStrategy, builder.Build());
-    ///
-    ///     // Register tenant specific overrides and set up the
-    ///     // application container provider.
-    ///     _containerProvider = new ContainerProvider(mtc);
-    ///
-    ///     // Do other MVC setup like route registration, etc.
-    ///     ControllerBuilder.Current.SetControllerFactory(new AutofacControllerFactory(this.ContainerProvider));
-    ///     AreaRegistration.RegisterAllAreas();
-    ///     RegisterRoutes(RouteTable.Routes);
-    ///   }
-    /// }
-    /// </code>
-    /// <para>
-    /// Note that much of the above code is the standard ASP.NET application
-    /// wireup with Autofac. The important part is when you register the service
-    /// client - it needs to have a <see cref="TenantPropagationBehavior{TTenantId}"/>
-    /// attached to it that can get the container provider from the
-    /// current application.
-    /// </para>
-    /// <para>
-    /// The following snippet shows what registration of this behavior
-    /// looks like in a WCF application hosted in IIS:
-    /// </para>
-    /// <code lang="C#">
-    /// public class Global : System.Web.HttpApplication
-    /// {
-    ///   protected void Application_Start(object sender, EventArgs e)
-    ///   {
-    ///       // Create the tenant ID strategy. Required for multitenant integration.
-    ///       var tenantIdStrategy = new OperationContextTenantIdentificationStrategy();
-    ///
-    ///       // Register application-level dependencies and service implementations.
-    ///       var builder = new ContainerBuilder();
-    ///       builder.RegisterType&lt;BaseImplementation&gt;().As&lt;IMultitenantService&gt;();
-    ///       // ... and so on.
-    ///
-    ///       // Create the multitenant container.
-    ///       var mtc = new MultitenantContainer(tenantIdStrategy, builder.Build());
-    ///
-    ///       // Configure tenant-specific overrides and set the WCF host container.
-    ///       Autofac.Multitenant.Wcf.AutofacHostFactory.Container = mtc;
-    ///
-    ///       // Add a behavior to service hosts that get created so incoming messages
-    ///       // get inspected and the tenant ID can be parsed from message headers.
-    ///       Autofac.Multitenant.Wcf.AutofacHostFactory.HostConfigurationAction =
-    ///         host =&gt;
-    ///           host.Opening += (s, args) =&gt;
-    ///             host.Description.Behaviors.Add(new TenantPropagationBehavior&lt;string&gt;(tenantIdStrategy));
-    ///   }
-    /// }
-    /// </code>
-    /// <para>
-    /// Note that it is also very similar to standard wireup with Autofac WCF
-    /// integration, just that you use the multitenant WCF host, a multitenant
-    /// container, and a behavior to get the tenant ID from the operation context.
-    /// </para>
-    /// </example>
-    /// <seealso cref="TenantPropagationMessageInspector{TTenantId}"/>
-    /// <seealso cref="OperationContextTenantIdentificationStrategy"/>
-    public class TenantPropagationBehavior<TTenantId> : IServiceBehavior, IEndpointBehavior
+    /// <param name="tenantIdentificationStrategy">
+    /// The strategy to use for identifying the current tenant.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="tenantIdentificationStrategy" /> is <see langword="null" />.
+    /// </exception>
+    public TenantPropagationBehavior(ITenantIdentificationStrategy tenantIdentificationStrategy)
     {
-        /// <summary>
-        /// Gets the strategy used for identifying the current tenant.
-        /// </summary>
-        /// <value>
-        /// An <see cref="ITenantIdentificationStrategy"/>
-        /// used to identify the current tenant from the execution context.
-        /// </value>
-        public ITenantIdentificationStrategy TenantIdentificationStrategy { get; }
+        this.TenantIdentificationStrategy = tenantIdentificationStrategy ?? throw new ArgumentNullException(nameof(tenantIdentificationStrategy));
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the
-        /// <see cref="TenantPropagationBehavior{TTenantId}"/> class.
-        /// </summary>
-        /// <param name="tenantIdentificationStrategy">
-        /// The strategy to use for identifying the current tenant.
-        /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="tenantIdentificationStrategy" /> is <see langword="null" />.
-        /// </exception>
-        public TenantPropagationBehavior(ITenantIdentificationStrategy tenantIdentificationStrategy)
+    /// <summary>
+    /// Gets the strategy used for identifying the current tenant.
+    /// </summary>
+    /// <value>
+    /// An <see cref="ITenantIdentificationStrategy"/>
+    /// used to identify the current tenant from the execution context.
+    /// </value>
+    public ITenantIdentificationStrategy TenantIdentificationStrategy
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Implement to pass data at runtime to bindings to support custom behavior.
+    /// </summary>
+    /// <param name="endpoint">The endpoint to modify.</param>
+    /// <param name="bindingParameters">
+    /// The objects that binding elements require to support the behavior.
+    /// </param>
+    public virtual void AddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters)
+    {
+    }
+
+    /// <summary>
+    /// Provides the ability to pass custom data to binding elements to support the contract implementation.
+    /// </summary>
+    /// <param name="serviceDescription">The service description of the service.</param>
+    /// <param name="serviceHostBase">The host of the service.</param>
+    /// <param name="endpoints">The service endpoints.</param>
+    /// <param name="bindingParameters">
+    /// Custom objects to which binding elements have access.
+    /// </param>
+    public virtual void AddBindingParameters(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase, Collection<ServiceEndpoint> endpoints, BindingParameterCollection bindingParameters)
+    {
+    }
+
+    /// <summary>
+    /// Adds the <see cref="TenantPropagationMessageInspector{TTenantId}"/>
+    /// to the client.
+    /// </summary>
+    /// <param name="endpoint">The endpoint that is to be customized.</param>
+    /// <param name="clientRuntime">The client runtime to be customized.</param>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="clientRuntime" /> is <see langword="null" />.
+    /// </exception>
+    public virtual void ApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
+    {
+        if (clientRuntime == null)
         {
-            if (tenantIdentificationStrategy == null)
-            {
-                throw new ArgumentNullException(nameof(tenantIdentificationStrategy));
-            }
-
-            this.TenantIdentificationStrategy = tenantIdentificationStrategy;
+            throw new ArgumentNullException(nameof(clientRuntime));
         }
 
-        /// <summary>
-        /// Implement to pass data at runtime to bindings to support custom behavior.
-        /// </summary>
-        /// <param name="endpoint">The endpoint to modify.</param>
-        /// <param name="bindingParameters">
-        /// The objects that binding elements require to support the behavior.
-        /// </param>
-        public virtual void AddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters)
+        clientRuntime.MessageInspectors.Add(new TenantPropagationMessageInspector<TTenantId>(this.TenantIdentificationStrategy));
+    }
+
+    /// <summary>
+    /// Adds the <see cref="TenantPropagationMessageInspector{TTenantId}"/>
+    /// to the service endpoints.
+    /// </summary>
+    /// <param name="serviceDescription">The service description.</param>
+    /// <param name="serviceHostBase">The host that is currently being built.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="serviceHostBase" /> is <see langword="null" />.
+    /// </exception>
+    public virtual void ApplyDispatchBehavior(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase)
+    {
+        if (serviceHostBase == null)
         {
+            throw new ArgumentNullException(nameof(serviceHostBase));
         }
 
-        /// <summary>
-        /// Provides the ability to pass custom data to binding elements to support the contract implementation.
-        /// </summary>
-        /// <param name="serviceDescription">The service description of the service.</param>
-        /// <param name="serviceHostBase">The host of the service.</param>
-        /// <param name="endpoints">The service endpoints.</param>
-        /// <param name="bindingParameters">
-        /// Custom objects to which binding elements have access.
-        /// </param>
-        public virtual void AddBindingParameters(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase, Collection<ServiceEndpoint> endpoints, BindingParameterCollection bindingParameters)
+        foreach (ChannelDispatcher channelDispatcher in serviceHostBase.ChannelDispatchers)
         {
-        }
-
-        /// <summary>
-        /// Adds the <see cref="TenantPropagationMessageInspector{TTenantId}"/>
-        /// to the client.
-        /// </summary>
-        /// <param name="endpoint">The endpoint that is to be customized.</param>
-        /// <param name="clientRuntime">The client runtime to be customized.</param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="clientRuntime" /> is <see langword="null" />.
-        /// </exception>
-        public virtual void ApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
-        {
-            if (clientRuntime == null)
+            foreach (var endpointDispatcher in channelDispatcher.Endpoints)
             {
-                throw new ArgumentNullException(nameof(clientRuntime));
-            }
-
-            clientRuntime.MessageInspectors.Add(new TenantPropagationMessageInspector<TTenantId>(this.TenantIdentificationStrategy));
-        }
-
-        /// <summary>
-        /// Adds the <see cref="TenantPropagationMessageInspector{TTenantId}"/>
-        /// to the service endpoints.
-        /// </summary>
-        /// <param name="serviceDescription">The service description.</param>
-        /// <param name="serviceHostBase">The host that is currently being built.</param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="serviceHostBase" /> is <see langword="null" />.
-        /// </exception>
-        public virtual void ApplyDispatchBehavior(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase)
-        {
-            if (serviceHostBase == null)
-            {
-                throw new ArgumentNullException(nameof(serviceHostBase));
-            }
-
-            foreach (ChannelDispatcher channelDispatcher in serviceHostBase.ChannelDispatchers)
-            {
-                foreach (EndpointDispatcher endpointDispatcher in channelDispatcher.Endpoints)
-                {
-                    endpointDispatcher.DispatchRuntime.MessageInspectors.Add(new TenantPropagationMessageInspector<TTenantId>(this.TenantIdentificationStrategy));
-                }
+                endpointDispatcher.DispatchRuntime.MessageInspectors.Add(new TenantPropagationMessageInspector<TTenantId>(this.TenantIdentificationStrategy));
             }
         }
+    }
 
-        /// <summary>
-        /// Implements a modification or extension of the service across an endpoint.
-        /// </summary>
-        /// <param name="endpoint">The endpoint that exposes the contract.</param>
-        /// <param name="endpointDispatcher">The endpoint dispatcher to be modified or extended.</param>
-        public virtual void ApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher)
-        {
-        }
+    /// <summary>
+    /// Implements a modification or extension of the service across an endpoint.
+    /// </summary>
+    /// <param name="endpoint">The endpoint that exposes the contract.</param>
+    /// <param name="endpointDispatcher">The endpoint dispatcher to be modified or extended.</param>
+    public virtual void ApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher)
+    {
+    }
 
-        /// <summary>
-        /// Implement to confirm that the endpoint meets some intended criteria.
-        /// </summary>
-        /// <param name="endpoint">The endpoint to validate.</param>
-        public virtual void Validate(ServiceEndpoint endpoint)
-        {
-        }
+    /// <summary>
+    /// Implement to confirm that the endpoint meets some intended criteria.
+    /// </summary>
+    /// <param name="endpoint">The endpoint to validate.</param>
+    public virtual void Validate(ServiceEndpoint endpoint)
+    {
+    }
 
-        /// <summary>
-        /// Provides the ability to inspect the service host and the service description to confirm that the service can run successfully.
-        /// </summary>
-        /// <param name="serviceDescription">The service description.</param>
-        /// <param name="serviceHostBase">The service host that is currently being constructed.</param>
-        public virtual void Validate(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase)
-        {
-        }
+    /// <summary>
+    /// Provides the ability to inspect the service host and the service description to confirm that the service can run successfully.
+    /// </summary>
+    /// <param name="serviceDescription">The service description.</param>
+    /// <param name="serviceHostBase">The service host that is currently being constructed.</param>
+    public virtual void Validate(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase)
+    {
     }
 }

--- a/src/Autofac.Multitenant.Wcf/TenantPropagationMessageInspector.cs
+++ b/src/Autofac.Multitenant.Wcf/TenantPropagationMessageInspector.cs
@@ -1,5 +1,8 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// <copyright file="TenantPropagationMessageInspector.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Autofac.Multitenant.Wcf;
 
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -7,178 +10,173 @@ using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Dispatcher;
 
-namespace Autofac.Multitenant.Wcf
+/// <summary>
+/// Message inspector that helps in passing the tenant ID from a WCF client
+/// to the respective service.
+/// </summary>
+/// <typeparam name="TTenantId">
+/// The type of the tenant ID to propagate. Must be nullable and
+/// serializable so it can be added to a message header.
+/// </typeparam>
+/// <remarks>
+/// <para>
+/// Use this in conjunction with the <see cref="TenantPropagationBehavior{TTenantId}"/>
+/// to automatically get the tenant ID on the WCF client end, add the ID
+/// to a header on the outbound message, and have the tenant ID read from
+/// headers on the service side and added to the operation context in an
+/// <see cref="TenantIdentificationContextExtension"/>.
+/// This allows you, on the service side, to use the
+/// <see cref="OperationContextTenantIdentificationStrategy"/>
+/// as your registered <see cref="ITenantIdentificationStrategy"/>.
+/// </para>
+/// <para>
+/// For a usage example, see <see cref="TenantPropagationBehavior{TTenantId}"/>.
+/// </para>
+/// </remarks>
+/// <seealso cref="TenantPropagationBehavior{TTenantId}"/>
+public class TenantPropagationMessageInspector<TTenantId> : IClientMessageInspector, IDispatchMessageInspector
 {
     /// <summary>
-    /// Message inspector that helps in passing the tenant ID from a WCF client
-    /// to the respective service.
+    /// Namespace of the header that gets added to messages and carries tenant information.
     /// </summary>
-    /// <typeparam name="TTenantId">
-    /// The type of the tenant ID to propagate. Must be nullable and
-    /// serializable so it can be added to a message header.
-    /// </typeparam>
-    /// <remarks>
-    /// <para>
-    /// Use this in conjunction with the <see cref="TenantPropagationBehavior{TTenantId}"/>
-    /// to automatically get the tenant ID on the WCF client end, add the ID
-    /// to a header on the outbound message, and have the tenant ID read from
-    /// headers on the service side and added to the operation context in an
-    /// <see cref="TenantIdentificationContextExtension"/>.
-    /// This allows you, on the service side, to use the
-    /// <see cref="OperationContextTenantIdentificationStrategy"/>
-    /// as your registered <see cref="ITenantIdentificationStrategy"/>.
-    /// </para>
-    /// <para>
-    /// For a usage example, see <see cref="TenantPropagationBehavior{TTenantId}"/>.
-    /// </para>
-    /// </remarks>
-    /// <seealso cref="TenantPropagationBehavior{TTenantId}"/>
-    public class TenantPropagationMessageInspector<TTenantId> : IClientMessageInspector, IDispatchMessageInspector
+    protected const string TenantHeaderNamespace = "urn:Autofac.Multitenant";
+
+    /// <summary>
+    /// Name of the header that gets added to messages and carries the tenant ID.
+    /// </summary>
+    protected const string TenantHeaderName = "tenantId";
+
+    /// <summary>
+    /// Initializes a new instance of the
+    /// <see cref="TenantPropagationMessageInspector{TTenantId}"/> class.
+    /// </summary>
+    /// <param name="tenantIdentificationStrategy">
+    /// The strategy to use for identifying the current tenant.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="tenantIdentificationStrategy" /> is <see langword="null" />.
+    /// </exception>
+    public TenantPropagationMessageInspector(ITenantIdentificationStrategy tenantIdentificationStrategy)
     {
-        /// <summary>
-        /// Namespace of the header that gets added to messages and carries tenant information.
-        /// </summary>
-        protected const string TenantHeaderNamespace = "urn:Autofac.Multitenant";
+        this.TenantIdentificationStrategy = tenantIdentificationStrategy ?? throw new ArgumentNullException(nameof(tenantIdentificationStrategy));
+    }
 
-        /// <summary>
-        /// Name of the header that gets added to messages and carries the tenant ID.
-        /// </summary>
-        protected const string TenantHeaderName = "tenantId";
+    /// <summary>
+    /// Gets the strategy used for identifying the current tenant.
+    /// </summary>
+    /// <value>
+    /// An <see cref="ITenantIdentificationStrategy"/>
+    /// used to identify the current tenant from the execution context.
+    /// </value>
+    public ITenantIdentificationStrategy TenantIdentificationStrategy
+    {
+        get;
+    }
 
-        /// <summary>
-        /// Gets the strategy used for identifying the current tenant.
-        /// </summary>
-        /// <value>
-        /// An <see cref="ITenantIdentificationStrategy"/>
-        /// used to identify the current tenant from the execution context.
-        /// </value>
-        public ITenantIdentificationStrategy TenantIdentificationStrategy { get; }
+    /// <summary>
+    /// Enables inspection or modification of a message after a reply message
+    /// is received but prior to passing it back to the client application.
+    /// </summary>
+    /// <param name="reply">
+    /// The message to be transformed into types and handed back to the client
+    /// application.
+    /// </param>
+    /// <param name="correlationState">
+    /// Correlation state data.
+    /// </param>
+    public void AfterReceiveReply(ref Message reply, object correlationState)
+    {
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the
-        /// <see cref="TenantPropagationMessageInspector{TTenantId}"/> class.
-        /// </summary>
-        /// <param name="tenantIdentificationStrategy">
-        /// The strategy to use for identifying the current tenant.
-        /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="tenantIdentificationStrategy" /> is <see langword="null" />.
-        /// </exception>
-        public TenantPropagationMessageInspector(ITenantIdentificationStrategy tenantIdentificationStrategy)
+    /// <summary>
+    /// Inspects inbound message headers and adds an
+    /// <see cref="TenantIdentificationContextExtension"/>
+    /// to the current operation context with the tenant ID.
+    /// </summary>
+    /// <param name="request">The request message.</param>
+    /// <param name="channel">The incoming channel.</param>
+    /// <param name="instanceContext">The current service instance.</param>
+    /// <returns>
+    /// Always returns <see langword="null" />. There is no correlation state
+    /// value to be managed in this inspector.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="request" /> is <see langword="null" />.
+    /// </exception>
+    public object AfterReceiveRequest(ref Message request, IClientChannel channel, InstanceContext instanceContext)
+    {
+        if (request == null)
         {
-            if (tenantIdentificationStrategy == null)
-            {
-                throw new ArgumentNullException(nameof(tenantIdentificationStrategy));
-            }
-
-            this.TenantIdentificationStrategy = tenantIdentificationStrategy;
+            throw new ArgumentNullException(nameof(request));
         }
 
-        /// <summary>
-        /// Enables inspection or modification of a message after a reply message
-        /// is received but prior to passing it back to the client application.
-        /// </summary>
-        /// <param name="reply">
-        /// The message to be transformed into types and handed back to the client
-        /// application.
-        /// </param>
-        /// <param name="correlationState">
-        /// Correlation state data.
-        /// </param>
-        public void AfterReceiveReply(ref Message reply, object correlationState)
+        var context = OperationContext.Current;
+        try
         {
+            var tenantId = request.Headers.GetHeader<TTenantId>(TenantHeaderName, TenantHeaderNamespace);
+            context.Extensions.Add(new TenantIdentificationContextExtension { TenantId = tenantId });
+        }
+        catch (MessageHeaderException)
+        {
+            // The additional header won't be there when we update service
+            // references; only when the behavior is on the client end.
         }
 
-        /// <summary>
-        /// Inspects inbound message headers and adds an
-        /// <see cref="TenantIdentificationContextExtension"/>
-        /// to the current operation context with the tenant ID.
-        /// </summary>
-        /// <param name="request">The request message.</param>
-        /// <param name="channel">The incoming channel.</param>
-        /// <param name="instanceContext">The current service instance.</param>
-        /// <returns>
-        /// Always returns <see langword="null" />. There is no correlation state
-        /// value to be managed in this inspector.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="request" /> is <see langword="null" />.
-        /// </exception>
-        public object AfterReceiveRequest(ref Message request, IClientChannel channel, InstanceContext instanceContext)
+        return null;
+    }
+
+    /// <summary>
+    /// Adds the tenant ID to the outbound message headers.
+    /// </summary>
+    /// <param name="request">The message to be sent to the service.</param>
+    /// <param name="channel">The client object channel.</param>
+    /// <returns>
+    /// Always returns <see langword="null" />. There is no correlation state
+    /// value to be managed in this inspector.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="request" /> is <see langword="null" />.
+    /// </exception>
+    [SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0", Justification = "Validation is performed manually at the start of the method.")]
+    public object BeforeSendRequest(ref Message request, IClientChannel channel)
+    {
+        if (request == null)
         {
-            if (request == null)
-            {
-                throw new ArgumentNullException(nameof(request));
-            }
-
-            var context = OperationContext.Current;
-            try
-            {
-                var tenantId = request.Headers.GetHeader<TTenantId>(TenantHeaderName, TenantHeaderNamespace);
-                context.Extensions.Add(new TenantIdentificationContextExtension { TenantId = tenantId });
-            }
-            catch (MessageHeaderException)
-            {
-                // The additional header won't be there when we update service
-                // references; only when the behavior is on the client end.
-            }
-
-            return null;
+            throw new ArgumentNullException(nameof(request));
         }
 
-        /// <summary>
-        /// Adds the tenant ID to the outbound message headers.
-        /// </summary>
-        /// <param name="request">The message to be sent to the service.</param>
-        /// <param name="channel">The client object channel.</param>
-        /// <returns>
-        /// Always returns <see langword="null" />. There is no correlation state
-        /// value to be managed in this inspector.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="request" /> is <see langword="null" />.
-        /// </exception>
-        [SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
-        public object BeforeSendRequest(ref Message request, IClientChannel channel)
+        // ApplicationContainer is used rather than RequestLifetime because
+        // you don't want individual tenants overriding the mechanism
+        // that determines tenant.
+        TTenantId tenantId;
+        if (!this.TenantIdentificationStrategy.TryIdentifyTenant(out var contextTenantId))
         {
-            if (request == null)
-            {
-                throw new ArgumentNullException(nameof(request));
-            }
-
-            // ApplicationContainer is used rather than RequestLifetime because
-            // you don't want individual tenants overriding the mechanism
-            // that determines tenant.
-            TTenantId tenantId;
-            if (!this.TenantIdentificationStrategy.TryIdentifyTenant(out object contextTenantId))
-            {
-                tenantId = default;
-            }
-            else
-            {
-                tenantId = (TTenantId)contextTenantId;
-            }
-
-            MessageHeader tenantHeader = new MessageHeader<TTenantId>(tenantId).GetUntypedHeader(TenantHeaderName, TenantHeaderNamespace);
-            request.Headers.Add(tenantHeader);
-            return null;
+            tenantId = default;
+        }
+        else
+        {
+            tenantId = (TTenantId)contextTenantId;
         }
 
-        /// <summary>
-        /// Called after the operation has returned but before the reply message
-        /// is sent.
-        /// </summary>
-        /// <param name="reply">
-        /// The reply message. This value is <see langword="null" /> if the
-        /// operation is one way.
-        /// </param>
-        /// <param name="correlationState">
-        /// The correlation object returned from the
-        /// <see cref="IDispatchMessageInspector.AfterReceiveRequest"/>
-        /// method.
-        /// </param>
-        public void BeforeSendReply(ref Message reply, object correlationState)
-        {
-        }
+        var tenantHeader = new MessageHeader<TTenantId>(tenantId).GetUntypedHeader(TenantHeaderName, TenantHeaderNamespace);
+        request.Headers.Add(tenantHeader);
+        return null;
+    }
+
+    /// <summary>
+    /// Called after the operation has returned but before the reply message
+    /// is sent.
+    /// </summary>
+    /// <param name="reply">
+    /// The reply message. This value is <see langword="null" /> if the
+    /// operation is one way.
+    /// </param>
+    /// <param name="correlationState">
+    /// The correlation object returned from the
+    /// <see cref="IDispatchMessageInspector.AfterReceiveRequest"/>
+    /// method.
+    /// </param>
+    public void BeforeSendReply(ref Message reply, object correlationState)
+    {
     }
 }

--- a/test/Autofac.Multitenant.Wcf.Test/DynamicProxy/ServiceHostProxyGeneratorFixture.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/DynamicProxy/ServiceHostProxyGeneratorFixture.cs
@@ -22,7 +22,7 @@ namespace Autofac.Multitenant.Wcf.Test.DynamicProxy
         {
             var generator = new ServiceHostProxyGenerator();
             object target = new ServiceImplementation();
-            Type interfaceToProxy = typeof(IServiceContract);
+            var interfaceToProxy = typeof(IServiceContract);
             var proxy = generator.CreateWcfProxy(interfaceToProxy, target);
 
             // XUnit does not have "Assert.DoesNotThrow".
@@ -34,7 +34,7 @@ namespace Autofac.Multitenant.Wcf.Test.DynamicProxy
         {
             var generator = new ServiceHostProxyGenerator();
             object target = new ServiceImplementation();
-            Type interfaceToProxy = typeof(ServiceImplementation);
+            var interfaceToProxy = typeof(ServiceImplementation);
             Assert.Throws<ArgumentException>(() => generator.CreateWcfProxy(interfaceToProxy, target));
         }
 
@@ -43,7 +43,7 @@ namespace Autofac.Multitenant.Wcf.Test.DynamicProxy
         {
             var generator = new ServiceHostProxyGenerator();
             object target = new NotAServiceImplementation();
-            Type interfaceToProxy = typeof(INotAServiceContract);
+            var interfaceToProxy = typeof(INotAServiceContract);
             Assert.Throws<ArgumentException>(() => generator.CreateWcfProxy(interfaceToProxy, target));
         }
 
@@ -52,7 +52,7 @@ namespace Autofac.Multitenant.Wcf.Test.DynamicProxy
         {
             var generator = new ServiceHostProxyGenerator();
             object target = new ServiceImplementation();
-            Type interfaceToProxy = typeof(IServiceContractGeneric<>);
+            var interfaceToProxy = typeof(IServiceContractGeneric<>);
             Assert.Throws<ArgumentException>(() => generator.CreateWcfProxy(interfaceToProxy, target));
         }
 
@@ -70,7 +70,7 @@ namespace Autofac.Multitenant.Wcf.Test.DynamicProxy
         {
             var generator = new ServiceHostProxyGenerator();
             object target = null;
-            Type interfaceToProxy = typeof(IServiceContract);
+            var interfaceToProxy = typeof(IServiceContract);
             Assert.Throws<ArgumentNullException>(() => generator.CreateWcfProxy(interfaceToProxy, target));
         }
 
@@ -79,7 +79,7 @@ namespace Autofac.Multitenant.Wcf.Test.DynamicProxy
         {
             var generator = new ServiceHostProxyGenerator();
             object target = new NotAServiceImplementation();
-            Type interfaceToProxy = typeof(IServiceContract);
+            var interfaceToProxy = typeof(IServiceContract);
             Assert.Throws<ArgumentException>(() => generator.CreateWcfProxy(interfaceToProxy, target));
         }
 
@@ -104,7 +104,10 @@ namespace Autofac.Multitenant.Wcf.Test.DynamicProxy
 
         private class ServiceImplementation : IServiceContract
         {
-            public bool ProxyMethodCalled { get; set; }
+            public bool ProxyMethodCalled
+            {
+                get; set;
+            }
 
             public void MethodToProxy()
             {

--- a/test/Autofac.Multitenant.Wcf.Test/MultitenantServiceImplementationDataProviderFixture.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/MultitenantServiceImplementationDataProviderFixture.cs
@@ -82,7 +82,10 @@ namespace Autofac.Multitenant.Wcf.Test
 
         private class ServiceImplementation : IServiceContract
         {
-            public bool ProxyMethodCalled { get; set; }
+            public bool ProxyMethodCalled
+            {
+                get; set;
+            }
 
             public void MethodToProxy()
             {

--- a/test/Autofac.Multitenant.Wcf.Test/OperationContextTenantIdentificationStrategyFixture.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/OperationContextTenantIdentificationStrategyFixture.cs
@@ -11,8 +11,7 @@ namespace Autofac.Multitenant.Wcf.Test
         public void TryIdentifyTenant_NoOperationContext()
         {
             var strategy = new OperationContextTenantIdentificationStrategy();
-            object tenantId;
-            bool success = strategy.TryIdentifyTenant(out tenantId);
+            var success = strategy.TryIdentifyTenant(out _);
             Assert.False(success);
         }
     }

--- a/test/Autofac.Multitenant.Wcf.Test/Stubs/StubTenantIdentificationStrategy.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/Stubs/StubTenantIdentificationStrategy.cs
@@ -5,9 +5,15 @@ namespace Autofac.Multitenant.Wcf.Test.Stubs
 {
     public class StubTenantIdentificationStrategy : ITenantIdentificationStrategy
     {
-        public bool IdentificationSuccess { get; }
+        public bool IdentificationSuccess
+        {
+            get;
+        }
 
-        public object TenantId { get; set; }
+        public object TenantId
+        {
+            get; set;
+        }
 
         public StubTenantIdentificationStrategy()
         {


### PR DESCRIPTION
## Summary

- Standardize `.pre-commit-config.yaml`, `.editorconfig`, `build/stylecop.json`, `build/Source.ruleset`, `build/Test.ruleset` to match Autofac core
- Update `default.proj` Package target to pack individual projects
- Apply `dotnet format` code formatting
- Fix SA1201/SA1202 member ordering and SA1404 SuppressMessage justifications

## Test plan

- [ ] CI build passes
- [ ] All tests pass
- [ ] `pre-commit run --all-files` passes