### PR TITLE
Add end-to-end multitenant WCF hosting tests

### DIFF
--- a/test/Autofac.Multitenant.Wcf.Test/Autofac.Multitenant.Wcf.Test.csproj
+++ b/test/Autofac.Multitenant.Wcf.Test/Autofac.Multitenant.Wcf.Test.csproj
@@ -29,7 +29,8 @@
     <AdditionalFiles Include="..\..\build\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <!-- Pinned: 8.0.0 and later ship net8.0+ build assets only, so net481 silently gets no coverage collector. -->
+    <PackageReference Include="coverlet.collector" Version="[6.0.4]">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Multitenant.Wcf.Test/Integration/MultitenantHostingFixture.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/Integration/MultitenantHostingFixture.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Autofac.Multitenant.Wcf.Test.Stubs;
+using Xunit;
+
+namespace Autofac.Multitenant.Wcf.Test.Integration;
+
+/// <summary>
+/// Opens a real multitenant WCF host and pushes messages through the full
+/// pipeline, verifying that the tenant ID travels from client to service and
+/// selects the tenant's implementation.
+/// </summary>
+[Collection("WcfHosting")]
+public class MultitenantHostingFixture
+{
+    [WindowsFact]
+    public void NoTenantHeader_ServesApplicationImplementation()
+    {
+        var activity = new DependencyActivity();
+        using var container = CreateContainer(activity);
+        var baseAddress = WcfTestHarness.CreateBaseAddress();
+
+        WcfTestHarness.WithMultitenantContainer(container, () =>
+        {
+            var host = WcfTestHarness.CreateHost(typeof(IMultitenantEchoService), baseAddress, new OperationContextTenantIdentificationStrategy());
+            WcfTestHarness.WithOpenHost<IMultitenantEchoService>(host, baseAddress, address =>
+            {
+                // No propagation behavior on the client, so no tenant header at all.
+                WcfTestHarness.Invoke<IMultitenantEchoService>(address, null, channel =>
+                {
+                    Assert.Equal("base", channel.GetTenantName());
+                    Assert.Equal("hi", channel.Echo("hi"));
+                });
+            });
+        });
+    }
+
+    [WindowsFact]
+    public void TenantHeader_RoutesEachTenantToItsOwnImplementation()
+    {
+        var activity = new DependencyActivity();
+        using var container = CreateContainer(activity);
+        var baseAddress = WcfTestHarness.CreateBaseAddress();
+
+        WcfTestHarness.WithMultitenantContainer(container, () =>
+        {
+            var host = WcfTestHarness.CreateHost(typeof(IMultitenantEchoService), baseAddress, new OperationContextTenantIdentificationStrategy());
+            WcfTestHarness.WithOpenHost<IMultitenantEchoService>(host, baseAddress, address =>
+            {
+                Assert.Equal("tenant1", GetTenantName(address, "1"));
+                Assert.Equal("tenant2", GetTenantName(address, "2"));
+
+                // A null tenant ID is the documented way to mean "default tenant".
+                Assert.Equal("base", GetTenantName(address, null));
+            });
+        });
+    }
+
+    [WindowsFact]
+    public void UnconfiguredTenant_FallsBackToApplicationImplementation()
+    {
+        var activity = new DependencyActivity();
+        using var container = CreateContainer(activity);
+        var baseAddress = WcfTestHarness.CreateBaseAddress();
+
+        WcfTestHarness.WithMultitenantContainer(container, () =>
+        {
+            var host = WcfTestHarness.CreateHost(typeof(IMultitenantEchoService), baseAddress, new OperationContextTenantIdentificationStrategy());
+            WcfTestHarness.WithOpenHost<IMultitenantEchoService>(host, baseAddress, address =>
+            {
+                Assert.Equal("base", GetTenantName(address, "no-such-tenant"));
+            });
+        });
+    }
+
+    [WindowsFact]
+    public void TenantScopedDependency_IsInjectedAndReleased()
+    {
+        var activity = new DependencyActivity();
+        using var container = CreateContainer(activity);
+        var baseAddress = WcfTestHarness.CreateBaseAddress();
+        var dependencyIds = new List<string>();
+
+        WcfTestHarness.WithMultitenantContainer(container, () =>
+        {
+            var host = WcfTestHarness.CreateHost(typeof(IMultitenantEchoService), baseAddress, new OperationContextTenantIdentificationStrategy());
+            WcfTestHarness.WithOpenHost<IMultitenantEchoService>(host, baseAddress, address =>
+            {
+                WcfTestHarness.Invoke<IMultitenantEchoService>(address, TenantBehavior("1"), channel =>
+                {
+                    dependencyIds.Add(channel.GetDependencyId());
+                    dependencyIds.Add(channel.GetDependencyId());
+                });
+            });
+        });
+
+        // Asserted after the host closes so every instance context has ended.
+        Assert.NotEmpty(dependencyIds);
+        Assert.All(dependencyIds, id => Assert.True(activity.WasDisposed(id)));
+        Assert.Equal(activity.CreatedCount, activity.DisposedCount);
+    }
+
+    [WindowsFact]
+    public void SeparateSessions_GetSeparateServiceInstances()
+    {
+        var activity = new DependencyActivity();
+        using var container = CreateContainer(activity);
+        var baseAddress = WcfTestHarness.CreateBaseAddress();
+
+        WcfTestHarness.WithMultitenantContainer(container, () =>
+        {
+            var host = WcfTestHarness.CreateHost(typeof(IMultitenantEchoService), baseAddress, new OperationContextTenantIdentificationStrategy());
+            WcfTestHarness.WithOpenHost<IMultitenantEchoService>(host, baseAddress, address =>
+            {
+                Assert.NotEqual(GetInstanceId(address, "1"), GetInstanceId(address, "1"));
+            });
+        });
+    }
+
+    private static MultitenantContainer CreateContainer(DependencyActivity activity)
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterInstance(activity);
+        builder.RegisterType<TrackedDependency>().InstancePerLifetimeScope();
+        builder.RegisterType<BaseEchoService>().As<IMultitenantEchoService>();
+
+        var container = new MultitenantContainer(new OperationContextTenantIdentificationStrategy(), builder.Build());
+        container.ConfigureTenant("1", b => b.RegisterType<Tenant1EchoService>().As<IMultitenantEchoService>());
+        container.ConfigureTenant("2", b => b.RegisterType<Tenant2EchoService>().As<IMultitenantEchoService>());
+        return container;
+    }
+
+    private static TenantPropagationBehavior<string> TenantBehavior(string? tenantId)
+        => new(new StubTenantIdentificationStrategy { TenantId = tenantId });
+
+    private static string GetTenantName(Uri address, string? tenantId)
+    {
+        string? tenantName = null;
+        WcfTestHarness.Invoke<IMultitenantEchoService>(address, TenantBehavior(tenantId), channel => tenantName = channel.GetTenantName());
+        return tenantName!;
+    }
+
+    private static string GetInstanceId(Uri address, string? tenantId)
+    {
+        string? instanceId = null;
+        WcfTestHarness.Invoke<IMultitenantEchoService>(address, TenantBehavior(tenantId), channel => instanceId = channel.GetInstanceId());
+        return instanceId!;
+    }
+}

--- a/test/Autofac.Multitenant.Wcf.Test/Integration/ServiceDescriptionFixture.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/Integration/ServiceDescriptionFixture.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.ServiceModel;
+using Autofac.Multitenant.Wcf.Test.Stubs;
+using Xunit;
+
+namespace Autofac.Multitenant.Wcf.Test.Integration;
+
+/// <summary>
+/// Asserts the shape of the type a multitenant host is built on and the
+/// description WCF derives from it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These only construct a host, never open one, because WCF reads the hosted type's
+/// attributes in the <see cref="ServiceHost"/> constructor. That is also why nothing
+/// downstream - <c>HostConfigurationAction</c> included - can correct them: by the
+/// time a caller holds the host, configuration has already been matched.
+/// </para>
+/// <para>
+/// Assertions against <c>Description.ConfigurationName</c> are Windows-only; Mono
+/// leaves that property null.
+/// </para>
+/// </remarks>
+[Collection("WcfHosting")]
+public class ServiceDescriptionFixture
+{
+    [Fact]
+    public void HostedType_ImplementsContractWithoutDeclaringIt()
+    {
+        // The entire reason this package generates a type rather than handing WCF
+        // the interface: WCF rejects a class that both declares and inherits a
+        // service contract.
+        WithHost(typeof(IMultitenantEchoService), host =>
+        {
+            var hostedType = host.Description.ServiceType!;
+            Assert.Contains(typeof(IMultitenantEchoService), hostedType.GetInterfaces());
+            Assert.Empty(hostedType.GetCustomAttributes(typeof(ServiceContractAttribute), false));
+        });
+    }
+
+    [Fact]
+    public void MetadataBuddyClass_AttributesLandOnHostedType()
+    {
+        WithHost(typeof(INamedEchoService), host =>
+        {
+            var behavior = Assert.Single(host.Description.ServiceType!.GetCustomAttributes(typeof(ServiceBehaviorAttribute), false));
+            Assert.Equal("NamedEchoService", ((ServiceBehaviorAttribute)behavior).Name);
+            Assert.Equal(typeof(INamedEchoService).FullName, ((ServiceBehaviorAttribute)behavior).ConfigurationName);
+        });
+    }
+
+    [Fact]
+    public void MetadataBuddyClass_SetsServiceName()
+    {
+        WithHost(typeof(INamedEchoService), host => Assert.Equal("NamedEchoService", host.Description.Name));
+    }
+
+    [WindowsFact]
+    public void MetadataBuddyClass_SetsConfigurationName()
+    {
+        WithHost(typeof(INamedEchoService), host => Assert.Equal(typeof(INamedEchoService).FullName, host.Description.ConfigurationName));
+    }
+
+    [WindowsFact]
+    public void ContractWithoutMetadataBuddyClass_FallsBackToGeneratedTypeName()
+    {
+        // Documents the cost of not using a buddy class: configuration has to name
+        // the generated type.
+        WithHost(typeof(IMultitenantEchoService), host => Assert.Equal(host.Description.ServiceType!.FullName, host.Description.ConfigurationName));
+    }
+
+    private static void WithHost(Type contractType, Action<ServiceHost> assert)
+    {
+        var builder = new ContainerBuilder();
+        using var container = new MultitenantContainer(new OperationContextTenantIdentificationStrategy(), builder.Build());
+        var baseAddress = WcfTestHarness.CreateBaseAddress();
+        WcfTestHarness.WithMultitenantContainer(container, () =>
+        {
+            using var host = WcfTestHarness.CreateHost(contractType, baseAddress, new OperationContextTenantIdentificationStrategy());
+            assert(host);
+        });
+    }
+}

--- a/test/Autofac.Multitenant.Wcf.Test/Integration/WcfTestHarness.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/Integration/WcfTestHarness.cs
@@ -1,0 +1,174 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.ServiceModel;
+using System.ServiceModel.Description;
+using Autofac.Integration.Wcf;
+
+namespace Autofac.Multitenant.Wcf.Test.Integration;
+
+/// <summary>
+/// Helpers for standing up a real multitenant WCF <see cref="ServiceHost"/> over a
+/// <see cref="NetNamedPipeBinding"/>, invoking it through a client channel, and
+/// tearing everything down.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These helpers exercise the full WCF client/dispatcher/instance-provider
+/// pipeline. Host construction works anywhere, but opening a host runs on Windows
+/// only - Mono/macOS does not support named-pipe hosting.
+/// </para>
+/// <para>
+/// Channels are created one at a time rather than reused because
+/// <see cref="NetNamedPipeBinding"/> is sessionful: a channel is a session, a
+/// session is an instance context, and an instance context is one tenant lifetime
+/// scope. Routing a second tenant through an open channel would reuse the first
+/// tenant's scope.
+/// </para>
+/// </remarks>
+internal static class WcfTestHarness
+{
+    /// <summary>
+    /// Creates a unique base address so concurrent or repeated runs do not
+    /// collide on a pipe name.
+    /// </summary>
+    /// <returns>
+    /// A unique <c>net.pipe</c> base address.
+    /// </returns>
+    public static Uri CreateBaseAddress()
+        => new("net.pipe://localhost/autofac-multitenant-wcf-test/" + Guid.NewGuid().ToString("N"));
+
+    /// <summary>
+    /// Creates a multitenant service host for a service contract interface, wired
+    /// the way the documentation prescribes: the host reads the tenant ID from
+    /// inbound message headers into the operation context.
+    /// </summary>
+    /// <param name="contractType">
+    /// The service contract interface to host. The multitenant data provider turns
+    /// this into the concrete type WCF actually hosts.
+    /// </param>
+    /// <param name="baseAddress">
+    /// The base address for the host.
+    /// </param>
+    /// <param name="tenantIdentificationStrategy">
+    /// The strategy handed to the service-side propagation behavior.
+    /// </param>
+    /// <returns>
+    /// An unopened host for <paramref name="contractType"/>.
+    /// </returns>
+    public static ServiceHost CreateHost(Type contractType, Uri baseAddress, ITenantIdentificationStrategy tenantIdentificationStrategy)
+    {
+        var host = (ServiceHost)new AutofacServiceHostFactory().CreateServiceHost(contractType.AssemblyQualifiedName!, new[] { baseAddress });
+        host.Opening += (sender, args) => host.Description.Behaviors.Add(new TenantPropagationBehavior<string>(tenantIdentificationStrategy));
+        return host;
+    }
+
+    /// <summary>
+    /// Adds a named-pipe endpoint, opens the host, runs the given body against the
+    /// endpoint address, then closes the host.
+    /// </summary>
+    /// <typeparam name="TContract">
+    /// The service contract interface.
+    /// </typeparam>
+    /// <param name="serviceHost">
+    /// The host to open. Closed by this method.
+    /// </param>
+    /// <param name="baseAddress">
+    /// The base address the host was created with.
+    /// </param>
+    /// <param name="body">
+    /// Receives the endpoint address of the open host.
+    /// </param>
+    public static void WithOpenHost<TContract>(ServiceHost serviceHost, Uri baseAddress, Action<Uri> body)
+    {
+        var address = new Uri(baseAddress, "service");
+        serviceHost.AddServiceEndpoint(typeof(TContract), new NetNamedPipeBinding(), address);
+        serviceHost.Open();
+
+        try
+        {
+            body(address);
+        }
+        finally
+        {
+            serviceHost.Close();
+        }
+    }
+
+    /// <summary>
+    /// Creates a client channel, runs the given interaction, then closes the
+    /// channel and factory.
+    /// </summary>
+    /// <typeparam name="TContract">
+    /// The service contract interface.
+    /// </typeparam>
+    /// <param name="address">
+    /// The endpoint address to connect to.
+    /// </param>
+    /// <param name="clientBehavior">
+    /// An endpoint behavior to add to the client, or <see langword="null" /> for
+    /// none. Pass a <see cref="TenantPropagationBehavior{TTenantId}"/> to send a
+    /// tenant ID with the request.
+    /// </param>
+    /// <param name="act">
+    /// The client interaction to run.
+    /// </param>
+    public static void Invoke<TContract>(Uri address, IEndpointBehavior? clientBehavior, Action<TContract> act)
+        where TContract : class
+    {
+        var channelFactory = new ChannelFactory<TContract>(new NetNamedPipeBinding(), new EndpointAddress(address));
+        try
+        {
+            if (clientBehavior != null)
+            {
+                channelFactory.Endpoint.EndpointBehaviors.Add(clientBehavior);
+            }
+
+            var channel = channelFactory.CreateChannel();
+            var succeeded = false;
+            try
+            {
+                act(channel);
+                ((IClientChannel)(object)channel).Close();
+                succeeded = true;
+            }
+            finally
+            {
+                if (!succeeded)
+                {
+                    ((IClientChannel)(object)channel).Abort();
+                }
+            }
+        }
+        finally
+        {
+            ((IDisposable)channelFactory).Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Runs a test body with the given multitenant container and the multitenant
+    /// data provider installed on <see cref="AutofacHostFactory"/>, restoring the
+    /// previous state afterward.
+    /// </summary>
+    /// <param name="container">
+    /// The multitenant container to install.
+    /// </param>
+    /// <param name="test">
+    /// The test body to run.
+    /// </param>
+    public static void WithMultitenantContainer(MultitenantContainer container, Action test)
+    {
+        AutofacHostFactory.Container = container;
+        AutofacHostFactory.ServiceImplementationDataProvider = new MultitenantServiceImplementationDataProvider();
+        try
+        {
+            test();
+        }
+        finally
+        {
+            AutofacHostFactory.Container = null;
+            AutofacHostFactory.ServiceImplementationDataProvider = null;
+        }
+    }
+}

--- a/test/Autofac.Multitenant.Wcf.Test/Stubs/BaseEchoService.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/Stubs/BaseEchoService.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Multitenant.Wcf.Test.Stubs;
+
+/// <summary>
+/// Application-level implementation, registered in the application container and
+/// used by any tenant that does not override the contract.
+/// </summary>
+public class BaseEchoService : MultitenantEchoServiceBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BaseEchoService"/> class.
+    /// </summary>
+    /// <param name="dependency">
+    /// The injected dependency.
+    /// </param>
+    public BaseEchoService(TrackedDependency dependency)
+        : base(dependency)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override string TenantName => "base";
+}

--- a/test/Autofac.Multitenant.Wcf.Test/Stubs/DependencyActivity.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/Stubs/DependencyActivity.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Autofac.Multitenant.Wcf.Test.Stubs;
+
+/// <summary>
+/// Thread-safe log of <see cref="TrackedDependency"/> construction and disposal.
+/// Registered as a single instance so the service side and the test observe the
+/// same data.
+/// </summary>
+public class DependencyActivity
+{
+    private readonly ConcurrentDictionary<string, bool> _disposed = new();
+    private int _createdCount;
+
+    /// <summary>
+    /// Gets the number of dependencies created so far.
+    /// </summary>
+    public int CreatedCount => Volatile.Read(ref _createdCount);
+
+    /// <summary>
+    /// Gets the number of dependencies that have been disposed.
+    /// </summary>
+    public int DisposedCount => _disposed.Count(kvp => kvp.Value);
+
+    /// <summary>
+    /// Records the creation of a dependency and returns its new ID.
+    /// </summary>
+    /// <returns>
+    /// A unique ID for the created dependency.
+    /// </returns>
+    public string Created()
+    {
+        var id = "dep-" + Interlocked.Increment(ref _createdCount);
+        _disposed[id] = false;
+        return id;
+    }
+
+    /// <summary>
+    /// Records that the dependency with the given ID was disposed.
+    /// </summary>
+    /// <param name="id">
+    /// The dependency ID.
+    /// </param>
+    public void Disposed(string id) => _disposed[id] = true;
+
+    /// <summary>
+    /// Determines whether the dependency with the given ID was disposed.
+    /// </summary>
+    /// <param name="id">
+    /// The dependency ID.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if disposed; otherwise <see langword="false"/>.
+    /// </returns>
+    public bool WasDisposed(string id) => _disposed.TryGetValue(id, out var disposed) && disposed;
+}

--- a/test/Autofac.Multitenant.Wcf.Test/Stubs/IMultitenantEchoService.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/Stubs/IMultitenantEchoService.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.ServiceModel;
+
+namespace Autofac.Multitenant.Wcf.Test.Stubs;
+
+/// <summary>
+/// Service contract for multitenant hosting tests. Operations expose enough state
+/// to assert which tenant's implementation answered, whether successive calls hit
+/// the same instance, and whether dependencies were injected and released.
+/// </summary>
+[ServiceContract]
+public interface IMultitenantEchoService
+{
+    /// <summary>
+    /// Returns the ID of the injected dependency, proving constructor injection
+    /// reached the live service instance.
+    /// </summary>
+    /// <returns>
+    /// The injected dependency's identifier.
+    /// </returns>
+    [OperationContract]
+    string GetDependencyId();
+
+    /// <summary>
+    /// Returns a per-instance identifier so callers can tell whether successive
+    /// calls hit the same service instance.
+    /// </summary>
+    /// <returns>
+    /// The service instance identifier.
+    /// </returns>
+    [OperationContract]
+    string GetInstanceId();
+
+    /// <summary>
+    /// Returns the name of the implementation that answered, identifying the tenant
+    /// the call was routed to.
+    /// </summary>
+    /// <returns>
+    /// The answering implementation's tenant name.
+    /// </returns>
+    [OperationContract]
+    string GetTenantName();
+
+    /// <summary>
+    /// Echoes the supplied message back to the caller.
+    /// </summary>
+    /// <param name="message">
+    /// The message to echo.
+    /// </param>
+    /// <returns>
+    /// The same message.
+    /// </returns>
+    [OperationContract]
+    string Echo(string message);
+}

--- a/test/Autofac.Multitenant.Wcf.Test/Stubs/INamedEchoService.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/Stubs/INamedEchoService.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.ServiceModel;
+
+namespace Autofac.Multitenant.Wcf.Test.Stubs;
+
+/// <summary>
+/// Service contract that names a metadata buddy class, so tests can assert the
+/// buddy class attributes reach the generated host type and therefore the service
+/// description WCF matches against XML configuration.
+/// </summary>
+[ServiceContract]
+[ServiceMetadataType(typeof(NamedEchoServiceMetadata))]
+public interface INamedEchoService
+{
+    /// <summary>
+    /// Echoes the supplied message back to the caller.
+    /// </summary>
+    /// <param name="message">
+    /// The message to echo.
+    /// </param>
+    /// <returns>
+    /// The same message.
+    /// </returns>
+    [OperationContract]
+    string Echo(string message);
+}

--- a/test/Autofac.Multitenant.Wcf.Test/Stubs/MultitenantEchoServiceBase.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/Stubs/MultitenantEchoServiceBase.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Threading;
+
+namespace Autofac.Multitenant.Wcf.Test.Stubs;
+
+/// <summary>
+/// Base <see cref="IMultitenantEchoService"/> implementation that takes a
+/// <see cref="TrackedDependency"/> so tests can assert constructor injection and
+/// lifetime. Each instance gets a unique ID.
+/// </summary>
+public abstract class MultitenantEchoServiceBase : IMultitenantEchoService
+{
+    private static int _instanceCounter;
+
+    private readonly TrackedDependency _dependency;
+    private readonly string _instanceId;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MultitenantEchoServiceBase"/> class.
+    /// </summary>
+    /// <param name="dependency">
+    /// The injected dependency whose ID is exposed via <see cref="GetDependencyId"/>.
+    /// </param>
+    protected MultitenantEchoServiceBase(TrackedDependency dependency)
+    {
+        _dependency = dependency ?? throw new ArgumentNullException(nameof(dependency));
+        _instanceId = "svc-" + Interlocked.Increment(ref _instanceCounter);
+    }
+
+    /// <summary>
+    /// Gets the tenant name reported by this implementation.
+    /// </summary>
+    public abstract string TenantName
+    {
+        get;
+    }
+
+    /// <inheritdoc/>
+    public string GetDependencyId() => _dependency.Id;
+
+    /// <inheritdoc/>
+    public string GetInstanceId() => _instanceId;
+
+    /// <inheritdoc/>
+    public string GetTenantName() => TenantName;
+
+    /// <inheritdoc/>
+    public string Echo(string message) => message;
+}

--- a/test/Autofac.Multitenant.Wcf.Test/Stubs/NamedEchoServiceMetadata.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/Stubs/NamedEchoServiceMetadata.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.ServiceModel;
+
+namespace Autofac.Multitenant.Wcf.Test.Stubs;
+
+/// <summary>
+/// Metadata buddy class for <see cref="INamedEchoService"/>. Setting
+/// <see cref="ServiceBehaviorAttribute.ConfigurationName"/> is the documented
+/// reason this feature exists: without it the generated host type's name is what
+/// the <c>&lt;service&gt;</c> element in configuration has to match.
+/// </summary>
+[ServiceBehavior(Name = "NamedEchoService", ConfigurationName = "Autofac.Multitenant.Wcf.Test.Stubs.INamedEchoService")]
+public class NamedEchoServiceMetadata
+{
+}

--- a/test/Autofac.Multitenant.Wcf.Test/Stubs/Tenant1EchoService.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/Stubs/Tenant1EchoService.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Multitenant.Wcf.Test.Stubs;
+
+/// <summary>
+/// Tenant-specific implementation registered as an override for tenant 1.
+/// </summary>
+public class Tenant1EchoService : MultitenantEchoServiceBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Tenant1EchoService"/> class.
+    /// </summary>
+    /// <param name="dependency">
+    /// The injected dependency.
+    /// </param>
+    public Tenant1EchoService(TrackedDependency dependency)
+        : base(dependency)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override string TenantName => "tenant1";
+}

--- a/test/Autofac.Multitenant.Wcf.Test/Stubs/Tenant2EchoService.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/Stubs/Tenant2EchoService.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Multitenant.Wcf.Test.Stubs;
+
+/// <summary>
+/// Tenant-specific implementation registered as an override for tenant 2.
+/// </summary>
+public class Tenant2EchoService : MultitenantEchoServiceBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Tenant2EchoService"/> class.
+    /// </summary>
+    /// <param name="dependency">
+    /// The injected dependency.
+    /// </param>
+    public Tenant2EchoService(TrackedDependency dependency)
+        : base(dependency)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override string TenantName => "tenant2";
+}

--- a/test/Autofac.Multitenant.Wcf.Test/Stubs/TrackedDependency.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/Stubs/TrackedDependency.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Multitenant.Wcf.Test.Stubs;
+
+/// <summary>
+/// A disposable dependency whose construction and disposal are recorded on a
+/// shared <see cref="DependencyActivity"/>, letting tests observe how many
+/// instances were created and disposed across service invocations.
+/// </summary>
+public class TrackedDependency : IDisposable
+{
+    private readonly DependencyActivity _activity;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TrackedDependency"/> class.
+    /// </summary>
+    /// <param name="activity">
+    /// The shared activity log this dependency records to.
+    /// </param>
+    public TrackedDependency(DependencyActivity activity)
+    {
+        _activity = activity ?? throw new ArgumentNullException(nameof(activity));
+        Id = _activity.Created();
+    }
+
+    /// <summary>
+    /// Gets the unique ID assigned to this instance at construction.
+    /// </summary>
+    public string Id
+    {
+        get;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => _activity.Disposed(Id);
+}

--- a/test/Autofac.Multitenant.Wcf.Test/WindowsFactAttribute.cs
+++ b/test/Autofac.Multitenant.Wcf.Test/WindowsFactAttribute.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.InteropServices;
+
+namespace Autofac.Multitenant.Wcf.Test;
+
+/// <summary>
+/// A <see cref="FactAttribute"/> that only runs on Windows.
+/// </summary>
+/// <remarks>
+/// <para>
+/// WCF self-hosting (named pipes, full ServiceHost pipeline) is unavailable
+/// under Mono/.NET on macOS and Linux, so end-to-end hosting tests are skipped
+/// off Windows while still running on CI.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class WindowsFactAttribute : FactAttribute
+{
+    public WindowsFactAttribute()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Skip = "WCF self-hosting is only supported on Windows.";
+        }
+    }
+}


### PR DESCRIPTION
Adds end-to-end WCF hosting coverage for multitenant service hosting. Related to #11 but does not resolve it: the behavior the generated host type exists to produce had no coverage, which made evaluating that issue guesswork.

## Proposed Changes

- `Integration/WcfTestHarness.cs` stands up a real named-pipe `ServiceHost` through `AutofacServiceHostFactory` with the multitenant data provider installed, wired the way the documentation prescribes. Opening a host and creating a channel are separate calls because `NetNamedPipeBinding` is sessionful — a channel is a session is an instance context is one tenant scope — so routing a second tenant needs a second channel.
- `Integration/MultitenantHostingFixture.cs` pushes messages through the full pipeline: no tenant header falls back to the application implementation, tenant IDs route to their own implementations, an unconfigured tenant falls back, tenant-scoped dependencies are injected and released, and separate sessions get separate instances.
- `Integration/ServiceDescriptionFixture.cs` asserts the hosted type implements the contract without declaring it, and that `ServiceMetadataTypeAttribute` buddy-class attributes reach both the generated type and the service description. It only constructs hosts, because WCF reads the hosted type's attributes in the `ServiceHost` constructor.
- Stubs and `WindowsFactAttribute` follow the Autofac.Wcf suite; the three files that already exist there are byte-identical apart from the namespace.

## Notes

`WindowsFactAttribute` skips the five hosting tests off Windows, so a local run on macOS is 41 passed / 7 skipped. The other two skips are `Description.ConfigurationName` assertions, which Mono leaves null. Windows CI is the first place the hosting tests actually execute.
